### PR TITLE
New implementation of tokenizer

### DIFF
--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -15,23 +15,18 @@ class JackTokenizer
       next_index = @input.index(" ", @index)
     end
 
-    current_chars = @input[@index...next_index]
+    @current_token = @input[@index...next_index]
 
-    if SYMBOL_TOKENS.include?(current_chars)
+    if SYMBOL_TOKENS.include?(@current_token)
       @token_type = :SYMBOL
-      @current_token = current_chars
-    elsif KEYWORD_TOKENS.include?(current_chars)
+    elsif KEYWORD_TOKENS.include?(@current_token)
       @token_type = :KEYWORD
-      @current_token = current_chars.upcase.to_sym
-    elsif DIGITS.include?(current_chars[0])
+    elsif DIGITS.include?(@current_token[0])
       @token_type = :INT_CONST
-      @current_token = current_chars.to_i
-    elsif current_chars.start_with?('"')
+    elsif @current_token.start_with?('"')
       @token_type = :STRING_CONST
-      @current_token = current_chars[1...-1]
     else
       @token_type = :IDENTIFIER
-      @current_token = current_chars
     end
 
     if next_index.nil?
@@ -50,7 +45,7 @@ class JackTokenizer
   end
 
   def key_word
-    @current_token
+    @current_token.upcase.to_sym
   end
 
   def symbol
@@ -62,10 +57,10 @@ class JackTokenizer
   end
 
   def int_val
-    @current_token
+    @current_token.to_i
   end
 
   def string_val
-    @current_token
+    @current_token[1...-1]
   end
 end

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -15,6 +15,12 @@ class JackTokenizer
     end
 
     next_index = @input.index(" ", @index)
+    current_chars = @input[@index...next_index]
+
+    if KEYWORD_TOKENS.include?(current_chars)
+      @token_type = :KEYWORD
+    end
+
     if next_index.nil?
       @index = @input.length
     else

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -9,6 +9,12 @@ class JackTokenizer
   end
 
   def advance
+    next_index = @input.index(" ", @index)
+    if next_index.nil?
+      @index = @input.length
+    else
+      @index = next_index + 1
+    end
   end
 
   KEYWORD_TOKENS = %w[class method function constructor int boolean char void var static field let do if else while return true false null this]

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -16,6 +16,8 @@ class JackTokenizer
       @token_type = :SYMBOL
     elsif KEYWORD_TOKENS.include?(current_chars)
       @token_type = :KEYWORD
+    else
+      @token_type = :IDENTIFIER
     end
 
     if next_index.nil?

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -9,7 +9,12 @@ class JackTokenizer
   end
 
   def advance
-    next_index = @input.index(" ", @index)
+    if @input[@index] == '"'
+      next_index = @input.index('"', @index + 1)
+    else
+      next_index = @input.index(" ", @index)
+    end
+
     current_chars = @input[@index...next_index]
 
     if SYMBOL_TOKENS.include?(current_chars)

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -10,7 +10,7 @@ class JackTokenizer
 
   def advance
     if @input[@index] == '"'
-      next_index = @input.index('"', @index + 1)
+      next_index = @input.index('"', @index + 1) + 1
     else
       next_index = @input.index(" ", @index)
     end
@@ -25,6 +25,7 @@ class JackTokenizer
       @token_type = :INT_CONST
     elsif current_chars.start_with?('"')
       @token_type = :STRING_CONST
+      @current_token = current_chars[1...-1]
     else
       @token_type = :IDENTIFIER
     end
@@ -57,5 +58,6 @@ class JackTokenizer
   end
 
   def string_val
+    @current_token
   end
 end

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -29,6 +29,7 @@ class JackTokenizer
       @current_token = current_chars[1...-1]
     else
       @token_type = :IDENTIFIER
+      @current_token = current_chars
     end
 
     if next_index.nil?
@@ -53,6 +54,7 @@ class JackTokenizer
   end
 
   def identifier
+    @current_token
   end
 
   def int_val

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -1,53 +1,34 @@
 class JackTokenizer
   def initialize(io)
-    @raw_tokens = io.read.split(/\s(?=(?:[^"]|"[^"]*")*$)/)
+    @input = io.read
+    @index = 0
   end
 
   def has_more_tokens?
-    !@raw_tokens.empty?
+    @index < @input.length
   end
 
   def advance
-    @current_token = @raw_tokens.shift
   end
 
   KEYWORD_TOKENS = %w[class method function constructor int boolean char void var static field let do if else while return true false null this]
   SYMBOL_TOKENS =  %w[{ } ( ) [ ] . , ; + - * / & | < > = ~]
 
   def token_type
-    begin
-      Integer(@current_token)
-      return :INT_CONST
-    rescue ArgumentError; end
-
-    if @current_token.start_with?('"')
-      :STRING_CONST
-    elsif SYMBOL_TOKENS.include?(@current_token)
-      :SYMBOL
-    elsif KEYWORD_TOKENS.include?(@current_token)
-      :KEYWORD
-    elsif @current_token.is_a?(String)
-      :IDENTIFIER
-    end
   end
 
   def key_word
-    @current_token.upcase.to_sym
   end
 
   def symbol
-    @current_token
   end
 
   def identifier
-    @current_token
   end
 
   def int_val
-    Integer(@current_token)
   end
 
   def string_val
-    @current_token[1..-2]
   end
 end

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -23,6 +23,7 @@ class JackTokenizer
       @token_type = :KEYWORD
     elsif DIGITS.include?(current_chars[0])
       @token_type = :INT_CONST
+      @current_token = current_chars.to_i
     elsif current_chars.start_with?('"')
       @token_type = :STRING_CONST
       @current_token = current_chars[1...-1]
@@ -55,6 +56,7 @@ class JackTokenizer
   end
 
   def int_val
+    @current_token
   end
 
   def string_val

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -19,6 +19,7 @@ class JackTokenizer
 
     if SYMBOL_TOKENS.include?(current_chars)
       @token_type = :SYMBOL
+      @current_token = current_chars
     elsif KEYWORD_TOKENS.include?(current_chars)
       @token_type = :KEYWORD
     elsif DIGITS.include?(current_chars[0])
@@ -51,6 +52,7 @@ class JackTokenizer
   end
 
   def symbol
+    @current_token
   end
 
   def identifier

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -16,6 +16,8 @@ class JackTokenizer
       @token_type = :SYMBOL
     elsif KEYWORD_TOKENS.include?(current_chars)
       @token_type = :KEYWORD
+    elsif DIGITS.include?(current_chars[0])
+      @token_type = :INT_CONST
     else
       @token_type = :IDENTIFIER
     end
@@ -29,6 +31,7 @@ class JackTokenizer
 
   KEYWORD_TOKENS = %w[class method function constructor int boolean char void var static field let do if else while return true false null this]
   SYMBOL_TOKENS =  %w[{ } ( ) [ ] . , ; + - * / & | < > = ~]
+  DIGITS = %w[0 1 2 3 4 5 6 7 8 9]
 
   def token_type
     @token_type

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -22,6 +22,7 @@ class JackTokenizer
       @current_token = current_chars
     elsif KEYWORD_TOKENS.include?(current_chars)
       @token_type = :KEYWORD
+      @current_token = current_chars.upcase.to_sym
     elsif DIGITS.include?(current_chars[0])
       @token_type = :INT_CONST
       @current_token = current_chars.to_i
@@ -49,6 +50,7 @@ class JackTokenizer
   end
 
   def key_word
+    @current_token
   end
 
   def symbol

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -18,6 +18,8 @@ class JackTokenizer
       @token_type = :KEYWORD
     elsif DIGITS.include?(current_chars[0])
       @token_type = :INT_CONST
+    elsif current_chars.start_with?('"')
+      @token_type = :STRING_CONST
     else
       @token_type = :IDENTIFIER
     end

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -9,6 +9,11 @@ class JackTokenizer
   end
 
   def advance
+    current_char = @input[@index]
+    if SYMBOL_TOKENS.include?(current_char)
+      @token_type = :SYMBOL
+    end
+
     next_index = @input.index(" ", @index)
     if next_index.nil?
       @index = @input.length
@@ -21,6 +26,7 @@ class JackTokenizer
   SYMBOL_TOKENS =  %w[{ } ( ) [ ] . , ; + - * / & | < > = ~]
 
   def token_type
+    @token_type
   end
 
   def key_word

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -9,15 +9,12 @@ class JackTokenizer
   end
 
   def advance
-    current_char = @input[@index]
-    if SYMBOL_TOKENS.include?(current_char)
-      @token_type = :SYMBOL
-    end
-
     next_index = @input.index(" ", @index)
     current_chars = @input[@index...next_index]
 
-    if KEYWORD_TOKENS.include?(current_chars)
+    if SYMBOL_TOKENS.include?(current_chars)
+      @token_type = :SYMBOL
+    elsif KEYWORD_TOKENS.include?(current_chars)
       @token_type = :KEYWORD
     end
 

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -52,13 +52,13 @@ class JackTokenizerTest < Minitest::Test
     assert_equal(:KEYWORD, jack_tokenizer.token_type)
   end
 
-  # def test_token_type_for_another_key_word
-  #   io = StringIO.new("static")
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   assert_equal(:KEYWORD, jack_tokenizer.token_type)
-  # end
+  def test_token_type_for_another_key_word
+    io = StringIO.new("static")
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    assert_equal(:KEYWORD, jack_tokenizer.token_type)
+  end
 
   # def test_token_type_for_identifiers
   #   io = StringIO.new("FooBar")

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -14,184 +14,184 @@ class JackTokenizerTest < Minitest::Test
     assert(jack_tokenizer.has_more_tokens?)
   end
 
-  def test_advance_to_end_of_file
-    io = StringIO.new("class Foo { }")
-    jack_tokenizer = JackTokenizer.new(io)
-    4.times do
-      jack_tokenizer.has_more_tokens?
-      jack_tokenizer.advance
-    end
-    refute(jack_tokenizer.has_more_tokens?)
-  end
+  # def test_advance_to_end_of_file
+  #   io = StringIO.new("class Foo { }")
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   4.times do
+  #     jack_tokenizer.has_more_tokens?
+  #     jack_tokenizer.advance
+  #   end
+  #   refute(jack_tokenizer.has_more_tokens?)
+  # end
 
-  def test_token_type_for_symbol
-    io = StringIO.new("{")
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    assert_equal(:SYMBOL, jack_tokenizer.token_type)
-  end
+  # def test_token_type_for_symbol
+  #   io = StringIO.new("{")
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   assert_equal(:SYMBOL, jack_tokenizer.token_type)
+  # end
 
-  def test_token_type_for_another_symbol
-    io = StringIO.new("~")
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    assert_equal(:SYMBOL, jack_tokenizer.token_type)
-  end
+  # def test_token_type_for_another_symbol
+  #   io = StringIO.new("~")
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   assert_equal(:SYMBOL, jack_tokenizer.token_type)
+  # end
 
-  def test_token_type_for_key_word
-    io = StringIO.new("class")
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    assert_equal(:KEYWORD, jack_tokenizer.token_type)
-  end
+  # def test_token_type_for_key_word
+  #   io = StringIO.new("class")
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   assert_equal(:KEYWORD, jack_tokenizer.token_type)
+  # end
 
-  def test_token_type_for_another_key_word
-    io = StringIO.new("static")
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    assert_equal(:KEYWORD, jack_tokenizer.token_type)
-  end
+  # def test_token_type_for_another_key_word
+  #   io = StringIO.new("static")
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   assert_equal(:KEYWORD, jack_tokenizer.token_type)
+  # end
 
-  def test_token_type_for_identifiers
-    io = StringIO.new("FooBar")
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    assert_equal(:IDENTIFIER, jack_tokenizer.token_type)
-  end
+  # def test_token_type_for_identifiers
+  #   io = StringIO.new("FooBar")
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   assert_equal(:IDENTIFIER, jack_tokenizer.token_type)
+  # end
 
-  def test_token_type_for_identifiers_with_special_chars
-    io = StringIO.new("Foo_Bar1")
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    assert_equal(:IDENTIFIER, jack_tokenizer.token_type)
-  end
+  # def test_token_type_for_identifiers_with_special_chars
+  #   io = StringIO.new("Foo_Bar1")
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   assert_equal(:IDENTIFIER, jack_tokenizer.token_type)
+  # end
 
-  def test_token_type_for_int_values
-    io = StringIO.new("999")
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    assert_equal(:INT_CONST, jack_tokenizer.token_type)
-  end
+  # def test_token_type_for_int_values
+  #   io = StringIO.new("999")
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   assert_equal(:INT_CONST, jack_tokenizer.token_type)
+  # end
 
-  def test_token_type_for_string_values
-    io = StringIO.new('"a"')
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    assert_equal(:STRING_CONST, jack_tokenizer.token_type)
-  end
+  # def test_token_type_for_string_values
+  #   io = StringIO.new('"a"')
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   assert_equal(:STRING_CONST, jack_tokenizer.token_type)
+  # end
 
-  def test_token_type_for_string_values_with_spaces
-    io = StringIO.new('" a "')
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    assert_equal(:STRING_CONST, jack_tokenizer.token_type)
-  end
+  # def test_token_type_for_string_values_with_spaces
+  #   io = StringIO.new('" a "')
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   assert_equal(:STRING_CONST, jack_tokenizer.token_type)
+  # end
 
-  def test_string_val_returns_string_token
-    io = StringIO.new('"a"')
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    assert_equal(:STRING_CONST, jack_tokenizer.token_type)
-    assert_equal("a", jack_tokenizer.string_val)
-  end
+  # def test_string_val_returns_string_token
+  #   io = StringIO.new('"a"')
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   assert_equal(:STRING_CONST, jack_tokenizer.token_type)
+  #   assert_equal("a", jack_tokenizer.string_val)
+  # end
 
-  def test_string_val_returns_string_token_with_spaces
-    io = StringIO.new('"a foo bar"')
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    assert_equal(:STRING_CONST, jack_tokenizer.token_type)
-    assert_equal("a foo bar", jack_tokenizer.string_val)
-  end
+  # def test_string_val_returns_string_token_with_spaces
+  #   io = StringIO.new('"a foo bar"')
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   assert_equal(:STRING_CONST, jack_tokenizer.token_type)
+  #   assert_equal("a foo bar", jack_tokenizer.string_val)
+  # end
 
-  def test_string_val_returns_string_token_with_spaces_2
-    io = StringIO.new('" a foo bar"')
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    assert_equal(:STRING_CONST, jack_tokenizer.token_type)
-    assert_equal(" a foo bar", jack_tokenizer.string_val)
-  end
+  # def test_string_val_returns_string_token_with_spaces_2
+  #   io = StringIO.new('" a foo bar"')
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   assert_equal(:STRING_CONST, jack_tokenizer.token_type)
+  #   assert_equal(" a foo bar", jack_tokenizer.string_val)
+  # end
 
-  def test_string_val_returns_string_token_with_spaces_3
-    io = StringIO.new('"a foo bar "')
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    assert_equal(:STRING_CONST, jack_tokenizer.token_type)
-    assert_equal("a foo bar ", jack_tokenizer.string_val)
-  end
+  # def test_string_val_returns_string_token_with_spaces_3
+  #   io = StringIO.new('"a foo bar "')
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   assert_equal(:STRING_CONST, jack_tokenizer.token_type)
+  #   assert_equal("a foo bar ", jack_tokenizer.string_val)
+  # end
 
-  def test_string_val_returns_string_token_with_spaces_4
-    io = StringIO.new('" a foo bar "')
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    assert_equal(:STRING_CONST, jack_tokenizer.token_type)
-    assert_equal(" a foo bar ", jack_tokenizer.string_val)
-  end
+  # def test_string_val_returns_string_token_with_spaces_4
+  #   io = StringIO.new('" a foo bar "')
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   assert_equal(:STRING_CONST, jack_tokenizer.token_type)
+  #   assert_equal(" a foo bar ", jack_tokenizer.string_val)
+  # end
 
-  def test_string_val_returns_string_token_with_spaces_5
-    io = StringIO.new('" a foo    bar "')
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    assert_equal(:STRING_CONST, jack_tokenizer.token_type)
-    assert_equal(" a foo    bar ", jack_tokenizer.string_val)
-  end
+  # def test_string_val_returns_string_token_with_spaces_5
+  #   io = StringIO.new('" a foo    bar "')
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   assert_equal(:STRING_CONST, jack_tokenizer.token_type)
+  #   assert_equal(" a foo    bar ", jack_tokenizer.string_val)
+  # end
 
-  def test_int_val_returns_integer
-    io = StringIO.new("999")
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    jack_tokenizer.token_type
-    assert_equal(999, jack_tokenizer.int_val)
-  end
+  # def test_int_val_returns_integer
+  #   io = StringIO.new("999")
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   jack_tokenizer.token_type
+  #   assert_equal(999, jack_tokenizer.int_val)
+  # end
 
-  def test_identifier_returns_string_identifier
-    io = StringIO.new("FooBar")
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    jack_tokenizer.token_type
-    assert_equal("FooBar", jack_tokenizer.identifier)
-  end
+  # def test_identifier_returns_string_identifier
+  #   io = StringIO.new("FooBar")
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   jack_tokenizer.token_type
+  #   assert_equal("FooBar", jack_tokenizer.identifier)
+  # end
 
-  def test_identifier_returns_string_identifier_special_characters
-    io = StringIO.new("Foo_Bar1")
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    jack_tokenizer.token_type
-    assert_equal("Foo_Bar1", jack_tokenizer.identifier)
-  end
+  # def test_identifier_returns_string_identifier_special_characters
+  #   io = StringIO.new("Foo_Bar1")
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   jack_tokenizer.token_type
+  #   assert_equal("Foo_Bar1", jack_tokenizer.identifier)
+  # end
 
-  def test_symbol_returns_symbol
-    io = StringIO.new("~")
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    jack_tokenizer.token_type
-    assert_equal("~", jack_tokenizer.symbol)
-  end
+  # def test_symbol_returns_symbol
+  #   io = StringIO.new("~")
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   jack_tokenizer.token_type
+  #   assert_equal("~", jack_tokenizer.symbol)
+  # end
 
-  def test_symbol_returns_key_world
-    io = StringIO.new("class")
-    jack_tokenizer = JackTokenizer.new(io)
-    jack_tokenizer.has_more_tokens?
-    jack_tokenizer.advance
-    jack_tokenizer.token_type
-    assert_equal(:CLASS, jack_tokenizer.key_word)
-  end
+  # def test_symbol_returns_key_world
+  #   io = StringIO.new("class")
+  #   jack_tokenizer = JackTokenizer.new(io)
+  #   jack_tokenizer.has_more_tokens?
+  #   jack_tokenizer.advance
+  #   jack_tokenizer.token_type
+  #   assert_equal(:CLASS, jack_tokenizer.key_word)
+  # end
 end

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -14,15 +14,15 @@ class JackTokenizerTest < Minitest::Test
     assert(jack_tokenizer.has_more_tokens?)
   end
 
-  # def test_advance_to_end_of_file
-  #   io = StringIO.new("class Foo { }")
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   4.times do
-  #     jack_tokenizer.has_more_tokens?
-  #     jack_tokenizer.advance
-  #   end
-  #   refute(jack_tokenizer.has_more_tokens?)
-  # end
+  def test_advance_to_end_of_file
+    io = StringIO.new("class Foo { }")
+    jack_tokenizer = JackTokenizer.new(io)
+    4.times do
+      jack_tokenizer.has_more_tokens?
+      jack_tokenizer.advance
+    end
+    refute(jack_tokenizer.has_more_tokens?)
+  end
 
   # def test_token_type_for_symbol
   #   io = StringIO.new("{")

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -84,13 +84,13 @@ class JackTokenizerTest < Minitest::Test
     assert_equal(:INT_CONST, jack_tokenizer.token_type)
   end
 
-  # def test_token_type_for_string_values
-  #   io = StringIO.new('"a"')
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   assert_equal(:STRING_CONST, jack_tokenizer.token_type)
-  # end
+  def test_token_type_for_string_values
+    io = StringIO.new('"a"')
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    assert_equal(:STRING_CONST, jack_tokenizer.token_type)
+  end
 
   # def test_token_type_for_string_values_with_spaces
   #   io = StringIO.new('" a "')

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -155,14 +155,14 @@ class JackTokenizerTest < Minitest::Test
     assert_equal(" a foo    bar ", jack_tokenizer.string_val)
   end
 
-  # def test_int_val_returns_integer
-  #   io = StringIO.new("999")
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   jack_tokenizer.token_type
-  #   assert_equal(999, jack_tokenizer.int_val)
-  # end
+  def test_int_val_returns_integer
+    io = StringIO.new("999")
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    jack_tokenizer.token_type
+    assert_equal(999, jack_tokenizer.int_val)
+  end
 
   # def test_identifier_returns_string_identifier
   #   io = StringIO.new("FooBar")

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -164,23 +164,23 @@ class JackTokenizerTest < Minitest::Test
     assert_equal(999, jack_tokenizer.int_val)
   end
 
-  # def test_identifier_returns_string_identifier
-  #   io = StringIO.new("FooBar")
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   jack_tokenizer.token_type
-  #   assert_equal("FooBar", jack_tokenizer.identifier)
-  # end
+  def test_identifier_returns_string_identifier
+    io = StringIO.new("FooBar")
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    jack_tokenizer.token_type
+    assert_equal("FooBar", jack_tokenizer.identifier)
+  end
 
-  # def test_identifier_returns_string_identifier_special_characters
-  #   io = StringIO.new("Foo_Bar1")
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   jack_tokenizer.token_type
-  #   assert_equal("Foo_Bar1", jack_tokenizer.identifier)
-  # end
+  def test_identifier_returns_string_identifier_special_characters
+    io = StringIO.new("Foo_Bar1")
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    jack_tokenizer.token_type
+    assert_equal("Foo_Bar1", jack_tokenizer.identifier)
+  end
 
   # def test_symbol_returns_symbol
   #   io = StringIO.new("~")

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -44,13 +44,13 @@ class JackTokenizerTest < Minitest::Test
     assert_equal(:SYMBOL, jack_tokenizer.token_type)
   end
 
-  # def test_token_type_for_key_word
-  #   io = StringIO.new("class")
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   assert_equal(:KEYWORD, jack_tokenizer.token_type)
-  # end
+  def test_token_type_for_key_word
+    io = StringIO.new("class")
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    assert_equal(:KEYWORD, jack_tokenizer.token_type)
+  end
 
   # def test_token_type_for_another_key_word
   #   io = StringIO.new("static")

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -191,12 +191,12 @@ class JackTokenizerTest < Minitest::Test
     assert_equal("~", jack_tokenizer.symbol)
   end
 
-  # def test_symbol_returns_key_world
-  #   io = StringIO.new("class")
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   jack_tokenizer.token_type
-  #   assert_equal(:CLASS, jack_tokenizer.key_word)
-  # end
+  def test_symbol_returns_key_word
+    io = StringIO.new("class")
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    jack_tokenizer.token_type
+    assert_equal(:CLASS, jack_tokenizer.key_word)
+  end
 end

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -60,21 +60,21 @@ class JackTokenizerTest < Minitest::Test
     assert_equal(:KEYWORD, jack_tokenizer.token_type)
   end
 
-  # def test_token_type_for_identifiers
-  #   io = StringIO.new("FooBar")
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   assert_equal(:IDENTIFIER, jack_tokenizer.token_type)
-  # end
+  def test_token_type_for_identifiers
+    io = StringIO.new("FooBar")
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    assert_equal(:IDENTIFIER, jack_tokenizer.token_type)
+  end
 
-  # def test_token_type_for_identifiers_with_special_chars
-  #   io = StringIO.new("Foo_Bar1")
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   assert_equal(:IDENTIFIER, jack_tokenizer.token_type)
-  # end
+  def test_token_type_for_identifiers_with_special_chars
+    io = StringIO.new("Foo_Bar1")
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    assert_equal(:IDENTIFIER, jack_tokenizer.token_type)
+  end
 
   # def test_token_type_for_int_values
   #   io = StringIO.new("999")

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -24,6 +24,10 @@ class JackTokenizerTest < Minitest::Test
     refute(jack_tokenizer.has_more_tokens?)
   end
 
+  def test_advance_with_multiple_whitespace
+    skip
+  end
+
   # def test_token_type_for_symbol
   #   io = StringIO.new("{")
   #   jack_tokenizer = JackTokenizer.new(io)

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -101,59 +101,59 @@ class JackTokenizerTest < Minitest::Test
     assert_equal(:STRING_CONST, jack_tokenizer.token_type)
   end
 
-  # def test_string_val_returns_string_token
-  #   io = StringIO.new('"a"')
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   assert_equal(:STRING_CONST, jack_tokenizer.token_type)
-  #   assert_equal("a", jack_tokenizer.string_val)
-  # end
+  def test_string_val_returns_string_token
+    io = StringIO.new('"a"')
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    assert_equal(:STRING_CONST, jack_tokenizer.token_type)
+    assert_equal("a", jack_tokenizer.string_val)
+  end
 
-  # def test_string_val_returns_string_token_with_spaces
-  #   io = StringIO.new('"a foo bar"')
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   assert_equal(:STRING_CONST, jack_tokenizer.token_type)
-  #   assert_equal("a foo bar", jack_tokenizer.string_val)
-  # end
+  def test_string_val_returns_string_token_with_spaces
+    io = StringIO.new('"a foo bar"')
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    assert_equal(:STRING_CONST, jack_tokenizer.token_type)
+    assert_equal("a foo bar", jack_tokenizer.string_val)
+  end
 
-  # def test_string_val_returns_string_token_with_spaces_2
-  #   io = StringIO.new('" a foo bar"')
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   assert_equal(:STRING_CONST, jack_tokenizer.token_type)
-  #   assert_equal(" a foo bar", jack_tokenizer.string_val)
-  # end
+  def test_string_val_returns_string_token_with_spaces_2
+    io = StringIO.new('" a foo bar"')
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    assert_equal(:STRING_CONST, jack_tokenizer.token_type)
+    assert_equal(" a foo bar", jack_tokenizer.string_val)
+  end
 
-  # def test_string_val_returns_string_token_with_spaces_3
-  #   io = StringIO.new('"a foo bar "')
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   assert_equal(:STRING_CONST, jack_tokenizer.token_type)
-  #   assert_equal("a foo bar ", jack_tokenizer.string_val)
-  # end
+  def test_string_val_returns_string_token_with_spaces_3
+    io = StringIO.new('"a foo bar "')
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    assert_equal(:STRING_CONST, jack_tokenizer.token_type)
+    assert_equal("a foo bar ", jack_tokenizer.string_val)
+  end
 
-  # def test_string_val_returns_string_token_with_spaces_4
-  #   io = StringIO.new('" a foo bar "')
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   assert_equal(:STRING_CONST, jack_tokenizer.token_type)
-  #   assert_equal(" a foo bar ", jack_tokenizer.string_val)
-  # end
+  def test_string_val_returns_string_token_with_spaces_4
+    io = StringIO.new('" a foo bar "')
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    assert_equal(:STRING_CONST, jack_tokenizer.token_type)
+    assert_equal(" a foo bar ", jack_tokenizer.string_val)
+  end
 
-  # def test_string_val_returns_string_token_with_spaces_5
-  #   io = StringIO.new('" a foo    bar "')
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   assert_equal(:STRING_CONST, jack_tokenizer.token_type)
-  #   assert_equal(" a foo    bar ", jack_tokenizer.string_val)
-  # end
+  def test_string_val_returns_string_token_with_spaces_5
+    io = StringIO.new('" a foo    bar "')
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    assert_equal(:STRING_CONST, jack_tokenizer.token_type)
+    assert_equal(" a foo    bar ", jack_tokenizer.string_val)
+  end
 
   # def test_int_val_returns_integer
   #   io = StringIO.new("999")

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -28,21 +28,21 @@ class JackTokenizerTest < Minitest::Test
     skip
   end
 
-  # def test_token_type_for_symbol
-  #   io = StringIO.new("{")
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   assert_equal(:SYMBOL, jack_tokenizer.token_type)
-  # end
+  def test_token_type_for_symbol
+    io = StringIO.new("{")
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    assert_equal(:SYMBOL, jack_tokenizer.token_type)
+  end
 
-  # def test_token_type_for_another_symbol
-  #   io = StringIO.new("~")
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   assert_equal(:SYMBOL, jack_tokenizer.token_type)
-  # end
+  def test_token_type_for_another_symbol
+    io = StringIO.new("~")
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    assert_equal(:SYMBOL, jack_tokenizer.token_type)
+  end
 
   # def test_token_type_for_key_word
   #   io = StringIO.new("class")

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -76,13 +76,13 @@ class JackTokenizerTest < Minitest::Test
     assert_equal(:IDENTIFIER, jack_tokenizer.token_type)
   end
 
-  # def test_token_type_for_int_values
-  #   io = StringIO.new("999")
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   assert_equal(:INT_CONST, jack_tokenizer.token_type)
-  # end
+  def test_token_type_for_int_values
+    io = StringIO.new("999")
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    assert_equal(:INT_CONST, jack_tokenizer.token_type)
+  end
 
   # def test_token_type_for_string_values
   #   io = StringIO.new('"a"')

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -92,13 +92,14 @@ class JackTokenizerTest < Minitest::Test
     assert_equal(:STRING_CONST, jack_tokenizer.token_type)
   end
 
-  # def test_token_type_for_string_values_with_spaces
-  #   io = StringIO.new('" a "')
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   assert_equal(:STRING_CONST, jack_tokenizer.token_type)
-  # end
+  def test_token_type_for_string_values_with_spaces
+    io = StringIO.new('"a foo bar"')
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    refute(jack_tokenizer.has_more_tokens?)
+    assert_equal(:STRING_CONST, jack_tokenizer.token_type)
+  end
 
   # def test_string_val_returns_string_token
   #   io = StringIO.new('"a"')

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -182,14 +182,14 @@ class JackTokenizerTest < Minitest::Test
     assert_equal("Foo_Bar1", jack_tokenizer.identifier)
   end
 
-  # def test_symbol_returns_symbol
-  #   io = StringIO.new("~")
-  #   jack_tokenizer = JackTokenizer.new(io)
-  #   jack_tokenizer.has_more_tokens?
-  #   jack_tokenizer.advance
-  #   jack_tokenizer.token_type
-  #   assert_equal("~", jack_tokenizer.symbol)
-  # end
+  def test_symbol_returns_symbol
+    io = StringIO.new("~")
+    jack_tokenizer = JackTokenizer.new(io)
+    jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    jack_tokenizer.token_type
+    assert_equal("~", jack_tokenizer.symbol)
+  end
 
   # def test_symbol_returns_key_world
   #   io = StringIO.new("class")


### PR DESCRIPTION
Utilizing previously written unit tests, we begin a new implementation for the tokenizer that allows a better control of the input string. 

The new implementation involves keeping track of two indices, the current index `@index`, and the index where we think the token ends `@next_index`. 

This PR manages to clear all of the previously written unit tests. And we're starting to think more deeply about intricate cases, such as whitespaces. 