### PR TITLE
Ignore non-tokens: whitespaces and inline comments 

### DIFF
--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -43,12 +43,10 @@ class JackTokenizer
 
     if next_index.nil?
       @index = @input.length
-    elsif @input[next_index] == " "
+    else
       while @input[next_index] == " "
         next_index += 1
       end
-      @index = next_index
-    else
       @index = next_index
     end
   end

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -44,7 +44,7 @@ class JackTokenizer
     if next_index.nil?
       @index = @input.length
     else
-      while @input[next_index] == " "
+      while WHITESPACES.include?(@input[next_index])
         next_index += 1
       end
       @index = next_index
@@ -54,6 +54,7 @@ class JackTokenizer
   KEYWORD_TOKENS = %w[class method function constructor int boolean char void var static field let do if else while return true false null this]
   SYMBOL_TOKENS =  %w[{ } ( ) [ ] . , ; + - * / & | < > = ~]
   DIGITS = %w[0 1 2 3 4 5 6 7 8 9]
+  WHITESPACES = [" ", "\n"]
 
   def token_type
     @token_type

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -4,6 +4,12 @@ class JackTokenizer
     @index = 0
   end
 
+  KEYWORD_TOKENS = %w[class method function constructor int boolean char void var static field let do if else while return true false null this]
+  SYMBOL_TOKENS =  %w[{ } ( ) [ ] . , ; + - * / & | < > = ~]
+  DIGITS = %w[0 1 2 3 4 5 6 7 8 9]
+  WHITESPACES = [" ", "\n"]
+  LETTERS = ("a".."z").to_a + ("A".."Z").to_a
+
   def has_more_tokens?
     while WHITESPACES.include?(@input[@index])
       @index += 1
@@ -58,11 +64,6 @@ class JackTokenizer
     end
   end
 
-  KEYWORD_TOKENS = %w[class method function constructor int boolean char void var static field let do if else while return true false null this]
-  SYMBOL_TOKENS =  %w[{ } ( ) [ ] . , ; + - * / & | < > = ~]
-  DIGITS = %w[0 1 2 3 4 5 6 7 8 9]
-  WHITESPACES = [" ", "\n"]
-
   def token_type
     @token_type
   end
@@ -88,8 +89,6 @@ class JackTokenizer
   end
 
   private
-
-  LETTERS = ("a".."z").to_a + ("A".."Z").to_a
 
   def is_start_of_identifier?(char)
     char == "_" || LETTERS.include?(char)

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -53,11 +53,7 @@ class JackTokenizer
       @token_type = :IDENTIFIER
     end
 
-    if next_index.nil?
-      @index = @input.length
-    else
-      @index = next_index
-    end
+    @index = next_index
   end
 
   def token_type

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -9,6 +9,10 @@ class JackTokenizer
   end
 
   def advance
+    while WHITESPACES.include?(@input[@index])
+      @index += 1
+    end
+
     if @input[@index] == '"'
       next_index = @input.index('"', @index + 1) + 1
     elsif is_start_of_identifier?(@input[@index])

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -44,7 +44,10 @@ class JackTokenizer
     if next_index.nil?
       @index = @input.length
     elsif @input[next_index] == " "
-      @index = next_index + 1
+      while @input[next_index] == " "
+        next_index += 1
+      end
+      @index = next_index
     else
       @index = next_index
     end

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -54,6 +54,12 @@ class JackTokenizer
     while WHITESPACES.include?(@input[@index])
       @index += 1
     end
+
+    if @input[@index] == "/"
+      while @input[@index] != "\n" && @index < @input.length
+        @index += 1
+      end
+    end
   end
 
   KEYWORD_TOKENS = %w[class method function constructor int boolean char void var static field let do if else while return true false null this]

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -5,14 +5,20 @@ class JackTokenizer
   end
 
   def has_more_tokens?
-    @index < @input.length
-  end
-
-  def advance
     while WHITESPACES.include?(@input[@index])
       @index += 1
     end
 
+    if @input[@index] == "/"
+      while @input[@index] != "\n" && @index < @input.length
+        @index += 1
+      end
+    end
+
+    @index < @input.length
+  end
+
+  def advance
     if @input[@index] == '"'
       next_index = @input.index('"', @index + 1) + 1
     elsif is_start_of_identifier?(@input[@index])

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -56,16 +56,6 @@ class JackTokenizer
     else
       @index = next_index
     end
-
-    while WHITESPACES.include?(@input[@index])
-      @index += 1
-    end
-
-    if @input[@index] == "/"
-      while @input[@index] != "\n" && @index < @input.length
-        @index += 1
-      end
-    end
   end
 
   KEYWORD_TOKENS = %w[class method function constructor int boolean char void var static field let do if else while return true false null this]

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -11,6 +11,18 @@ class JackTokenizer
   def advance
     if @input[@index] == '"'
       next_index = @input.index('"', @index + 1) + 1
+    elsif is_start_of_identifier?(@input[@index])
+      next_index = @index
+      while is_body_of_identifier?(@input[next_index])
+        next_index += 1
+      end
+    elsif SYMBOL_TOKENS.include?(@input[@index])
+      next_index = @index + 1
+    elsif DIGITS.include?(@input[@index])
+      next_index = @index
+      while DIGITS.include?(@input[next_index])
+        next_index += 1
+      end
     else
       next_index = @input.index(" ", @index)
     end
@@ -31,8 +43,10 @@ class JackTokenizer
 
     if next_index.nil?
       @index = @input.length
-    else
+    elsif @input[next_index] == " "
       @index = next_index + 1
+    else
+      @index = next_index
     end
   end
 
@@ -62,5 +76,17 @@ class JackTokenizer
 
   def string_val
     @current_token[1...-1]
+  end
+
+  private
+
+  LETTERS = ("a".."z").to_a + ("A".."Z").to_a
+
+  def is_start_of_identifier?(char)
+    char == "_" || LETTERS.include?(char)
+  end
+
+  def is_body_of_identifier?(char)
+    is_start_of_identifier?(char) || DIGITS.include?(char)
   end
 end

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -44,10 +44,10 @@ class JackTokenizer
     if next_index.nil?
       @index = @input.length
     else
-      while WHITESPACES.include?(@input[next_index])
-        next_index += 1
-      end
       @index = next_index
+      while WHITESPACES.include?(@input[@index])
+        @index += 1
+      end
     end
   end
 

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -49,9 +49,10 @@ class JackTokenizer
       @index = @input.length
     else
       @index = next_index
-      while WHITESPACES.include?(@input[@index])
-        @index += 1
-      end
+    end
+
+    while WHITESPACES.include?(@input[@index])
+      @index += 1
     end
   end
 

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -9,7 +9,7 @@ class JackTokenizer
       @index += 1
     end
 
-    if @input[@index] == "/"
+    if @input[@index] == "/" && @input[@index+1] == "/"
       while @input[@index] != "\n" && @index < @input.length
         @index += 1
       end

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -16,9 +16,7 @@ class JackTokenizer
     end
 
     if @input[@index] == "/" && @input[@index+1] == "/"
-      while @input[@index] != "\n" && @index < @input.length
-        @index += 1
-      end
+      @index = @input.index("\n", @index) || @input.length
     end
 
     @index < @input.length

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -39,8 +39,6 @@ class JackTokenizer
       while DIGITS.include?(@input[next_index])
         next_index += 1
       end
-    else
-      next_index = @input.index(" ", @index)
     end
 
     @current_token = @input[@index...next_index]

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -74,6 +74,12 @@ class JackTokenizerTest < Minitest::Test
     refute(jack_tokenizer.has_more_tokens?)
   end
 
+  def test_advance_through_leading_double_slash_comments
+    io = StringIO.new("// TODO xyz[123]")
+    jack_tokenizer = JackTokenizer.new(io)
+    refute(jack_tokenizer.has_more_tokens?)
+  end
+
   def test_token_type_for_symbol
     io = StringIO.new("{")
     jack_tokenizer = JackTokenizer.new(io)

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -24,7 +24,7 @@ class JackTokenizerTest < Minitest::Test
     refute(jack_tokenizer.has_more_tokens?)
   end
 
-  def test_advance_without_spaces
+  def test_has_more_tokens_skips_without_spaces
     io = StringIO.new("xyz[123]")
     jack_tokenizer = JackTokenizer.new(io)
     4.times do
@@ -34,7 +34,7 @@ class JackTokenizerTest < Minitest::Test
     refute(jack_tokenizer.has_more_tokens?)
   end
 
-  def test_advance_with_multiple_whitespaces
+  def test_has_more_tokens_skips_multiple_whitespaces
     io = StringIO.new("xyz[123]  ")
     jack_tokenizer = JackTokenizer.new(io)
     4.times do
@@ -44,7 +44,7 @@ class JackTokenizerTest < Minitest::Test
     refute(jack_tokenizer.has_more_tokens?)
   end
 
-  def test_advance_with_leading_whitespaces
+  def test_has_more_tokens_skips_leading_whitespaces
     io = StringIO.new(" xyz[123]")
     jack_tokenizer = JackTokenizer.new(io)
     4.times do
@@ -54,7 +54,7 @@ class JackTokenizerTest < Minitest::Test
     refute(jack_tokenizer.has_more_tokens?)
   end
 
-  def test_advance_with_different_whitespaces
+  def test_has_more_tokens_skips_different_whitespaces
     io = StringIO.new("xyz[123] \n")
     jack_tokenizer = JackTokenizer.new(io)
     4.times do
@@ -64,7 +64,7 @@ class JackTokenizerTest < Minitest::Test
     refute(jack_tokenizer.has_more_tokens?)
   end
 
-  def test_advance_through_trailing_double_slash_comments
+  def test_has_more_tokens_skips_trailing_double_slash_comments
     io = StringIO.new("xyz[123] // TODO")
     jack_tokenizer = JackTokenizer.new(io)
     4.times do
@@ -74,7 +74,7 @@ class JackTokenizerTest < Minitest::Test
     refute(jack_tokenizer.has_more_tokens?)
   end
 
-  def test_advance_through_leading_double_slash_comments
+  def test_has_more_tokens_skips_leading_double_slash_comments
     io = StringIO.new("// TODO xyz[123]")
     jack_tokenizer = JackTokenizer.new(io)
     refute(jack_tokenizer.has_more_tokens?)

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -34,8 +34,14 @@ class JackTokenizerTest < Minitest::Test
     refute(jack_tokenizer.has_more_tokens?)
   end
 
-  def test_advance_with_multiple_whitespace
-    skip
+  def test_advance_with_multiple_whitespaces
+    io = StringIO.new("xyz[123]  ")
+    jack_tokenizer = JackTokenizer.new(io)
+    4.times do
+      assert(jack_tokenizer.has_more_tokens?)
+      jack_tokenizer.advance
+    end
+    refute(jack_tokenizer.has_more_tokens?)
   end
 
   def test_token_type_for_symbol

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -251,4 +251,26 @@ class JackTokenizerTest < Minitest::Test
     jack_tokenizer.token_type
     assert_equal(:CLASS, jack_tokenizer.key_word)
   end
+
+  def test_division
+    io = StringIO.new('4 / 2')
+    jack_tokenizer = JackTokenizer.new(io)
+
+    assert jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    assert_equal(:INT_CONST, jack_tokenizer.token_type)
+    assert_equal(4, jack_tokenizer.int_val)
+
+    assert jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    assert_equal(:SYMBOL, jack_tokenizer.token_type)
+    assert_equal('/', jack_tokenizer.symbol)
+
+    assert jack_tokenizer.has_more_tokens?
+    jack_tokenizer.advance
+    assert_equal(:INT_CONST, jack_tokenizer.token_type)
+    assert_equal(2, jack_tokenizer.int_val)
+
+    refute(jack_tokenizer.has_more_tokens?)
+  end
 end

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -24,6 +24,16 @@ class JackTokenizerTest < Minitest::Test
     refute(jack_tokenizer.has_more_tokens?)
   end
 
+  def test_advance_without_spaces
+    io = StringIO.new("xyz[123]")
+    jack_tokenizer = JackTokenizer.new(io)
+    4.times do
+      assert(jack_tokenizer.has_more_tokens?)
+      jack_tokenizer.advance
+    end
+    refute(jack_tokenizer.has_more_tokens?)
+  end
+
   def test_advance_with_multiple_whitespace
     skip
   end

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -44,6 +44,16 @@ class JackTokenizerTest < Minitest::Test
     refute(jack_tokenizer.has_more_tokens?)
   end
 
+  def test_advance_with_leading_whitespaces
+    io = StringIO.new(" xyz[123]")
+    jack_tokenizer = JackTokenizer.new(io)
+    4.times do
+      assert(jack_tokenizer.has_more_tokens?)
+      jack_tokenizer.advance
+    end
+    refute(jack_tokenizer.has_more_tokens?)
+  end
+
   def test_advance_with_different_whitespaces
     io = StringIO.new("xyz[123] \n")
     jack_tokenizer = JackTokenizer.new(io)

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -44,6 +44,16 @@ class JackTokenizerTest < Minitest::Test
     refute(jack_tokenizer.has_more_tokens?)
   end
 
+  def test_advance_with_different_whitespaces
+    io = StringIO.new("xyz[123] \n")
+    jack_tokenizer = JackTokenizer.new(io)
+    4.times do
+      assert(jack_tokenizer.has_more_tokens?)
+      jack_tokenizer.advance
+    end
+    refute(jack_tokenizer.has_more_tokens?)
+  end
+
   def test_token_type_for_symbol
     io = StringIO.new("{")
     jack_tokenizer = JackTokenizer.new(io)

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -64,6 +64,16 @@ class JackTokenizerTest < Minitest::Test
     refute(jack_tokenizer.has_more_tokens?)
   end
 
+  def test_advance_through_trailing_double_slash_comments
+    io = StringIO.new("xyz[123] // TODO")
+    jack_tokenizer = JackTokenizer.new(io)
+    4.times do
+      assert(jack_tokenizer.has_more_tokens?)
+      jack_tokenizer.advance
+    end
+    refute(jack_tokenizer.has_more_tokens?)
+  end
+
   def test_token_type_for_symbol
     io = StringIO.new("{")
     jack_tokenizer = JackTokenizer.new(io)


### PR DESCRIPTION
## Changes

* Skips leading and trailing whitespaces: spaces and newline
* Skips leading and trailing forward slash (inline) comments 
* Refactor: move the skipping of non-tokens into `#has_more_tokens?`