### PR TITLE
Skip single and double asterisk comments 

### DIFF
--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -18,10 +18,10 @@ class JackTokenizer
         @index += 1
       end
 
-      if @input[@index] == "/" && @input[@index+1] == "/"
+      if @input[@index..@index+1] == "//"
         @index = @input.index("\n", @index) || @input.length
 
-      elsif @input[@index] == "/" && @input[@index+1] == "*"
+      elsif @input[@index..@index+1] == "/*"
         @index = @input.index("*/", @index) + 2
       end
 

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -11,15 +11,21 @@ class JackTokenizer
   LETTERS = ("a".."z").to_a + ("A".."Z").to_a
 
   def has_more_tokens?
-    while WHITESPACES.include?(@input[@index])
-      @index += 1
-    end
+    loop do
+      old_index = @index
 
-    if @input[@index] == "/" && @input[@index+1] == "/"
-      @index = @input.index("\n", @index) || @input.length
+      while WHITESPACES.include?(@input[@index])
+        @index += 1
+      end
 
-    elsif @input[@index] == "/" && @input[@index+1] == "*"
-      @index = @input.index("*/", @index) + 2
+      if @input[@index] == "/" && @input[@index+1] == "/"
+        @index = @input.index("\n", @index) || @input.length
+
+      elsif @input[@index] == "/" && @input[@index+1] == "*"
+        @index = @input.index("*/", @index) + 2
+      end
+
+      break if old_index == @index
     end
 
     @index < @input.length

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -17,6 +17,9 @@ class JackTokenizer
 
     if @input[@index] == "/" && @input[@index+1] == "/"
       @index = @input.index("\n", @index) || @input.length
+
+    elsif @input[@index] == "/" && @input[@index+1] == "*"
+      @index = @input.index("*/", @index) + 2
     end
 
     @index < @input.length

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -13,18 +13,8 @@ class JackTokenizer
   def has_more_tokens?
     loop do
       old_index = @index
-
-      while WHITESPACES.include?(@input[@index])
-        @index += 1
-      end
-
-      if @input[@index..@index+1] == "//"
-        @index = @input.index("\n", @index) || @input.length
-
-      elsif @input[@index..@index+1] == "/*"
-        @index = @input.index("*/", @index) + 2
-      end
-
+      skip_whitespace
+      skip_comments
       break if old_index == @index
     end
 
@@ -90,6 +80,21 @@ class JackTokenizer
   end
 
   private
+
+  def skip_whitespace
+    while WHITESPACES.include?(@input[@index])
+      @index += 1
+    end
+  end
+
+  def skip_comments
+    if @input[@index..@index+1] == "//"
+      @index = @input.index("\n", @index) || @input.length
+
+    elsif @input[@index..@index+1] == "/*"
+      @index = @input.index("*/", @index) + 2
+    end
+  end
 
   def is_start_of_identifier?(char)
     char == "_" || LETTERS.include?(char)

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -74,6 +74,16 @@ class JackTokenizerTest < Minitest::Test
     refute(jack_tokenizer.has_more_tokens?)
   end
 
+  def test_has_more_tokens_skips_leading_double_slash_comments_with_newline_code
+    io = StringIO.new("// TODO \nxyz[123]")
+    jack_tokenizer = JackTokenizer.new(io)
+    4.times do
+      assert(jack_tokenizer.has_more_tokens?)
+      jack_tokenizer.advance
+    end
+    refute(jack_tokenizer.has_more_tokens?)
+  end
+
   def test_has_more_tokens_skips_leading_double_slash_comments
     io = StringIO.new("// TODO xyz[123]")
     jack_tokenizer = JackTokenizer.new(io)
@@ -88,6 +98,12 @@ class JackTokenizerTest < Minitest::Test
 
   def test_has_more_tokens_skips_single_asterisk_comment_in_two_lines
     io = StringIO.new("/* TODO \n xyz[123] */")
+    jack_tokenizer = JackTokenizer.new(io)
+    refute(jack_tokenizer.has_more_tokens?)
+  end
+
+  def test_has_more_tokens_skips_multiple_comments
+    io = StringIO.new("/* TODO xyz[123] */ \n // lol")
     jack_tokenizer = JackTokenizer.new(io)
     refute(jack_tokenizer.has_more_tokens?)
   end

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -80,6 +80,18 @@ class JackTokenizerTest < Minitest::Test
     refute(jack_tokenizer.has_more_tokens?)
   end
 
+  def test_has_more_tokens_skips_single_asterisk_comment
+    io = StringIO.new("/* TODO xyz[123] */")
+    jack_tokenizer = JackTokenizer.new(io)
+    refute(jack_tokenizer.has_more_tokens?)
+  end
+
+  def test_has_more_tokens_skips_single_asterisk_comment_in_two_lines
+    io = StringIO.new("/* TODO \n xyz[123] */")
+    jack_tokenizer = JackTokenizer.new(io)
+    refute(jack_tokenizer.has_more_tokens?)
+  end
+
   def test_token_type_for_symbol
     io = StringIO.new("{")
     jack_tokenizer = JackTokenizer.new(io)

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -108,6 +108,12 @@ class JackTokenizerTest < Minitest::Test
     refute(jack_tokenizer.has_more_tokens?)
   end
 
+  def test_has_more_tokens_skips_double_asterisk_comment
+    io = StringIO.new("/** TODO xyz[123] */")
+    jack_tokenizer = JackTokenizer.new(io)
+    refute(jack_tokenizer.has_more_tokens?)
+  end
+
   def test_token_type_for_symbol
     io = StringIO.new("{")
     jack_tokenizer = JackTokenizer.new(io)


### PR DESCRIPTION
# Changes
The last bit of the tokenizer before we can fully test it in XML, which will be in the next PR. 
* Skip single and double asterisk comments 
* Refactor that loops through the whitespace and comment skipping to ensure we skip through _all_ whitespaces and comments when `has_more_tokens?` is called (and not just the first instance of it) 