### PR TITLE
Tokenize with regular expressions 

### DIFF
--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -23,16 +23,16 @@ class JackTokenizer
   def advance
     if (match = @input.match(%r{"[^"]*"}, @index)) && match.begin(0) == @index
       @current_token = match[0]
-      next_index = match.end(0)
+      @index = match.end(0)
     elsif (match = @input.match(%r{[_a-zA-Z][_a-zA-Z0-9]*}, @index)) && match.begin(0) == @index
       @current_token = match[0]
-      next_index = match.end(0)
+      @index = match.end(0)
     elsif (match = @input.match(%r{[{}()\[\].,;+\-*/&|<>=~]}, @index)) && match.begin(0) == @index
       @current_token = match[0]
-      next_index = match.end(0)
+      @index = match.end(0)
     elsif (match = @input.match(%r{[0-9]+}, @index)) && match.begin(0) == @index
       @current_token = match[0]
-      next_index = match.end(0)
+      @index = match.end(0)
     end
 
     if SYMBOL_TOKENS.include?(@current_token)
@@ -46,8 +46,6 @@ class JackTokenizer
     else
       @token_type = :IDENTIFIER
     end
-
-    @index = next_index
   end
 
   def token_type

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -9,8 +9,11 @@ class JackTokenizer
   def has_more_tokens?
     loop do
       old_index = @index
-      skip_whitespace
-      skip_comments
+
+      if (match = @input.match(%r{[ \n]+|//.*$|/\*(.|\n)*\*/}, @index)) && match.begin(0) == @index
+        @index = match.end(0)
+      end
+
       break if old_index == @index
     end
 
@@ -63,19 +66,5 @@ class JackTokenizer
 
   def string_val
     @current_token[1...-1]
-  end
-
-  private
-
-  def skip_whitespace
-    if (match = @input.match(%r{[ \n]*}, @index)) && match.begin(0) == @index
-      @index = match.end(0)
-    end
-  end
-
-  def skip_comments
-    if (match = @input.match(%r{//.*$|/\*(.|\n)*\*/}, @index)) && match.begin(0) == @index
-      @index = match.end(0)
-    end
   end
 end

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -74,11 +74,11 @@ class JackTokenizer
   end
 
   def skip_comments
-    if @input[@index..@index+1] == "//"
-      @index = @input.index("\n", @index) || @input.length
+    if (match = @input.match(%r{//.*$}, @index)) && match.begin(0) == @index
+      @index = match.end(0)
 
-    elsif @input[@index..@index+1] == "/*"
-      @index = @input.index("*/", @index) + 2
+    elsif (match = @input.match(%r{/\*(.|\n)*\*/}, @index)) && match.begin(0) == @index
+      @index = match.end(0)
     end
   end
 end

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -7,14 +7,8 @@ class JackTokenizer
   KEYWORD_TOKENS = %w[class method function constructor int boolean char void var static field let do if else while return true false null this]
 
   def has_more_tokens?
-    loop do
-      old_index = @index
-
-      if (match = @input.match(%r{[ \n]+|//.*$|/\*(.|\n)*\*/}, @index)) && match.begin(0) == @index
-        @index = match.end(0)
-      end
-
-      break if old_index == @index
+    if (match = @input.match(%r{([ \n]+|//.*$|/\*(.|\n)*\*/)+}, @index)) && match.begin(0) == @index
+      @index = match.end(0)
     end
 
     @index < @input.length

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -8,7 +8,6 @@ class JackTokenizer
   SYMBOL_TOKENS =  %w[{ } ( ) [ ] . , ; + - * / & | < > = ~]
   DIGITS = %w[0 1 2 3 4 5 6 7 8 9]
   WHITESPACES = [" ", "\n"]
-  LETTERS = ("a".."z").to_a + ("A".."Z").to_a
 
   def has_more_tokens?
     loop do
@@ -22,20 +21,14 @@ class JackTokenizer
   end
 
   def advance
-    if @input[@index] == '"'
-      next_index = @input.index('"', @index + 1) + 1
-    elsif is_start_of_identifier?(@input[@index])
-      next_index = @index
-      while is_body_of_identifier?(@input[next_index])
-        next_index += 1
-      end
-    elsif SYMBOL_TOKENS.include?(@input[@index])
-      next_index = @index + 1
-    elsif DIGITS.include?(@input[@index])
-      next_index = @index
-      while DIGITS.include?(@input[next_index])
-        next_index += 1
-      end
+    if (match = @input.match(%r{"[^"]*"}, @index)) && match.begin(0) == @index
+      next_index = match.end(0)
+    elsif (match = @input.match(%r{[_a-zA-Z][_a-zA-Z0-9]*}, @index)) && match.begin(0) == @index
+      next_index = match.end(0)
+    elsif (match = @input.match(%r{[{}()\[\].,;+\-*/&|<>=~]}, @index)) && match.begin(0) == @index
+      next_index = match.end(0)
+    elsif (match = @input.match(%r{[0-9]+}, @index)) && match.begin(0) == @index
+      next_index = match.end(0)
     end
 
     @current_token = @input[@index...next_index]
@@ -94,13 +87,5 @@ class JackTokenizer
     elsif @input[@index..@index+1] == "/*"
       @index = @input.index("*/", @index) + 2
     end
-  end
-
-  def is_start_of_identifier?(char)
-    char == "_" || LETTERS.include?(char)
-  end
-
-  def is_body_of_identifier?(char)
-    is_start_of_identifier?(char) || DIGITS.include?(char)
   end
 end

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -74,10 +74,7 @@ class JackTokenizer
   end
 
   def skip_comments
-    if (match = @input.match(%r{//.*$}, @index)) && match.begin(0) == @index
-      @index = match.end(0)
-
-    elsif (match = @input.match(%r{/\*(.|\n)*\*/}, @index)) && match.begin(0) == @index
+    if (match = @input.match(%r{//.*$|/\*(.|\n)*\*/}, @index)) && match.begin(0) == @index
       @index = match.end(0)
     end
   end

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -5,8 +5,6 @@ class JackTokenizer
   end
 
   KEYWORD_TOKENS = %w[class method function constructor int boolean char void var static field let do if else while return true false null this]
-  SYMBOL_TOKENS =  %w[{ } ( ) [ ] . , ; + - * / & | < > = ~]
-  DIGITS = %w[0 1 2 3 4 5 6 7 8 9]
   WHITESPACES = [" ", "\n"]
 
   def has_more_tokens?
@@ -24,27 +22,23 @@ class JackTokenizer
     if (match = @input.match(%r{"[^"]*"}, @index)) && match.begin(0) == @index
       @current_token = match[0]
       @index = match.end(0)
+      @token_type = :STRING_CONST
     elsif (match = @input.match(%r{[_a-zA-Z][_a-zA-Z0-9]*}, @index)) && match.begin(0) == @index
       @current_token = match[0]
       @index = match.end(0)
+      if KEYWORD_TOKENS.include?(@current_token)
+        @token_type = :KEYWORD
+      else
+        @token_type = :IDENTIFIER
+      end
     elsif (match = @input.match(%r{[{}()\[\].,;+\-*/&|<>=~]}, @index)) && match.begin(0) == @index
       @current_token = match[0]
       @index = match.end(0)
+      @token_type = :SYMBOL
     elsif (match = @input.match(%r{[0-9]+}, @index)) && match.begin(0) == @index
       @current_token = match[0]
       @index = match.end(0)
-    end
-
-    if SYMBOL_TOKENS.include?(@current_token)
-      @token_type = :SYMBOL
-    elsif KEYWORD_TOKENS.include?(@current_token)
-      @token_type = :KEYWORD
-    elsif DIGITS.include?(@current_token[0])
       @token_type = :INT_CONST
-    elsif @current_token.start_with?('"')
-      @token_type = :STRING_CONST
-    else
-      @token_type = :IDENTIFIER
     end
   end
 

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -22,16 +22,18 @@ class JackTokenizer
 
   def advance
     if (match = @input.match(%r{"[^"]*"}, @index)) && match.begin(0) == @index
+      @current_token = match[0]
       next_index = match.end(0)
     elsif (match = @input.match(%r{[_a-zA-Z][_a-zA-Z0-9]*}, @index)) && match.begin(0) == @index
+      @current_token = match[0]
       next_index = match.end(0)
     elsif (match = @input.match(%r{[{}()\[\].,;+\-*/&|<>=~]}, @index)) && match.begin(0) == @index
+      @current_token = match[0]
       next_index = match.end(0)
     elsif (match = @input.match(%r{[0-9]+}, @index)) && match.begin(0) == @index
+      @current_token = match[0]
       next_index = match.end(0)
     end
-
-    @current_token = @input[@index...next_index]
 
     if SYMBOL_TOKENS.include?(@current_token)
       @token_type = :SYMBOL

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -5,7 +5,6 @@ class JackTokenizer
   end
 
   KEYWORD_TOKENS = %w[class method function constructor int boolean char void var static field let do if else while return true false null this]
-  WHITESPACES = [" ", "\n"]
 
   def has_more_tokens?
     loop do
@@ -69,8 +68,8 @@ class JackTokenizer
   private
 
   def skip_whitespace
-    while WHITESPACES.include?(@input[@index])
-      @index += 1
+    if (match = @input.match(%r{[ \n]*}, @index)) && match.begin(0) == @index
+      @index = match.end(0)
     end
   end
 


### PR DESCRIPTION
For some learning fun, we refactored our tokenizer to use regular expressions. 

This change reduced the code by quite a bit because, 1) there is now no need for private helper method; 2) we can perform several checks using regular expression (e.g. skipping comments and whitespace) all in one condition, and 3) no need for constants. 

We can also now access information about the matched/current token more easily using methods from Ruby's [MatchData](https://ruby-doc.org/core-3.0.1/MatchData.html) library, such as `MatchData#end` and `MatchData#[]`.

In a separate PR, I'll refactor this code even more using Ruby's [`StringScanner`](https://ruby-doc.org/stdlib-3.0.0/libdoc/strscan/rdoc/StringScanner.html) library. StringScanner provides an API to scan through a string with a pointer using regular expressions, which is essentially what our current implementation does manually.   