### PR TITLE
Output tokens in XML format for comparison 

### DIFF
--- a/bin/tokenizer
+++ b/bin/tokenizer
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+
+require_relative '../lib/jack_tokenizer'
+
+input_file = File.open(ARGV[0])
+tokenizer = JackTokenizer.new(input_file)
+
+while tokenizer.has_more_tokens?
+  tokenizer.advance
+  puts tokenizer.token_type
+  puts tokenizer.symbol.inspect
+end

--- a/bin/tokenizer
+++ b/bin/tokenizer
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'cgi'
 require_relative '../lib/jack_tokenizer'
 
 input_file = File.open(ARGV[0])
@@ -14,10 +15,10 @@ while tokenizer.has_more_tokens?
     token = tokenizer.string_val
     token_type = "stringConstant"
   when :INT_CONST
-    token = tokenizer.int_val
+    token = tokenizer.int_val.to_s
     token_type = "integerConstant"
   when :KEYWORD
-    token = tokenizer.key_word.downcase
+    token = tokenizer.key_word.downcase.to_s
     token_type = "keyword"
   when :IDENTIFIER
     token = tokenizer.identifier
@@ -27,6 +28,6 @@ while tokenizer.has_more_tokens?
     token_type = "symbol"
   end
 
-  puts("  <#{token_type}> #{token} </#{token_type}>")
+  puts("  <#{token_type}> #{CGI.escapeHTML(token)} </#{token_type}>")
 end
 puts("</tokens>")

--- a/bin/tokenizer
+++ b/bin/tokenizer
@@ -13,6 +13,9 @@ while tokenizer.has_more_tokens?
   when :STRING_CONST
     token = tokenizer.string_val
     token_type = "stringConstant"
+  when :INT_CONST
+    token = tokenizer.int_val
+    token_type = "integerConstant"
   else
     token = tokenizer.symbol
     token_type = tokenizer.token_type.downcase

--- a/bin/tokenizer
+++ b/bin/tokenizer
@@ -9,7 +9,8 @@ puts("<tokens>")
 while tokenizer.has_more_tokens?
   tokenizer.advance
 
-  if tokenizer.token_type == :STRING_CONST
+  case tokenizer.token_type
+  when :STRING_CONST
     token = tokenizer.string_val
     token_type = "stringConstant"
   else

--- a/bin/tokenizer
+++ b/bin/tokenizer
@@ -5,8 +5,9 @@ require_relative '../lib/jack_tokenizer'
 input_file = File.open(ARGV[0])
 tokenizer = JackTokenizer.new(input_file)
 
+puts("<tokens>")
 while tokenizer.has_more_tokens?
   tokenizer.advance
-  puts tokenizer.token_type
-  puts tokenizer.symbol.inspect
+  puts("  <#{tokenizer.token_type.downcase}> #{tokenizer.symbol} </#{tokenizer.token_type.downcase}>")
 end
+puts("</tokens>")

--- a/bin/tokenizer
+++ b/bin/tokenizer
@@ -8,6 +8,15 @@ tokenizer = JackTokenizer.new(input_file)
 puts("<tokens>")
 while tokenizer.has_more_tokens?
   tokenizer.advance
-  puts("  <#{tokenizer.token_type.downcase}> #{tokenizer.symbol} </#{tokenizer.token_type.downcase}>")
+
+  if tokenizer.token_type == :STRING_CONST
+    token = tokenizer.string_val
+    token_type = "stringConstant"
+  else
+    token = tokenizer.symbol
+    token_type = tokenizer.token_type.downcase
+  end
+
+  puts("  <#{token_type}> #{token} </#{token_type}>")
 end
 puts("</tokens>")

--- a/bin/tokenizer
+++ b/bin/tokenizer
@@ -16,9 +16,15 @@ while tokenizer.has_more_tokens?
   when :INT_CONST
     token = tokenizer.int_val
     token_type = "integerConstant"
-  else
+  when :KEYWORD
+    token = tokenizer.key_word.downcase
+    token_type = "keyword"
+  when :IDENTIFIER
+    token = tokenizer.identifier
+    token_type = "identifier"
+  when :SYMBOL
     token = tokenizer.symbol
-    token_type = tokenizer.token_type.downcase
+    token_type = "symbol"
   end
 
   puts("  <#{token_type}> #{token} </#{token_type}>")

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -7,7 +7,7 @@ class JackTokenizer
   KEYWORD_TOKENS = %w[class method function constructor int boolean char void var static field let do if else while return true false null this]
 
   def has_more_tokens?
-    if (match = @input.match(%r{([ \n]+|//.*$|/\*(.|\n)*\*/)+}, @index)) && match.begin(0) == @index
+    if (match = @input.match(%r{([ \n\r\t]+|//.*$|/\*(.|\n)*\*/)+}, @index)) && match.begin(0) == @index
       @index = match.end(0)
     end
 


### PR DESCRIPTION
Now that the tokenizer is implemented, we created a bin script that takes a `.jack` file as an input and outputs tokens in an XML format. We can use a Java tool provided by the authors of EoCS, TextComparer to compare our tokenizer implementation with the provided XML files.

We've tested on the files: Square, ExpressionLessGame, and ArrayTest. However, I haven't implemented a way for the comparison to happen automatically yet.  