### PR TITLE
Start implementing CompilationEngine

### DIFF
--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -13,7 +13,7 @@ class CompilationEngine
     @output.puts("<identifier> #{@tokenizer.identifier} </identifier>")
 
     @tokenizer.has_more_tokens? && @tokenizer.advance
-    @output.puts("<symbol> { </symbol>")
+    @output.puts("<symbol> #{@tokenizer.symbol} </symbol>")
 
     @tokenizer.has_more_tokens? && @tokenizer.advance
     if @tokenizer.token_type == :KEYWORD
@@ -21,7 +21,7 @@ class CompilationEngine
     end
 
     @tokenizer.has_more_tokens? && @tokenizer.advance
-    @output.puts("<symbol> } </symbol>")
+    @output.puts("<symbol> #{@tokenizer.symbol} </symbol>")
     @output.puts("</class>")
   end
 
@@ -35,7 +35,8 @@ class CompilationEngine
     @tokenizer.has_more_tokens? && @tokenizer.advance
     @output.puts("<identifier> #{@tokenizer.identifier} </identifier>")
 
-    @output.puts("<symbol> ; </symbol>")
+    @tokenizer.has_more_tokens? && @tokenizer.advance
+    @output.puts("<symbol> #{@tokenizer.symbol} </symbol>")
     @output.puts("</classVarDec>")
   end
 end

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -31,8 +31,10 @@ class CompilationEngine
 
     @tokenizer.has_more_tokens? && @tokenizer.advance
     @output.puts("<keyword> #{@tokenizer.key_word.downcase.to_s} </keyword>")
-    
-    @output.puts("<identifier> bloop </identifier>")
+
+    @tokenizer.has_more_tokens? && @tokenizer.advance
+    @output.puts("<identifier> #{@tokenizer.identifier} </identifier>")
+
     @output.puts("<symbol> ; </symbol>")
     @output.puts("</classVarDec>")
   end

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -28,7 +28,10 @@ class CompilationEngine
   def compile_class_var_dec
     @output.puts("<classVarDec>")
     @output.puts("<keyword> #{@tokenizer.key_word.downcase.to_s} </keyword>")
-    @output.puts("<keyword> int </keyword>")
+
+    @tokenizer.has_more_tokens? && @tokenizer.advance
+    @output.puts("<keyword> #{@tokenizer.key_word.downcase.to_s} </keyword>")
+    
     @output.puts("<identifier> bloop </identifier>")
     @output.puts("<symbol> ; </symbol>")
     @output.puts("</classVarDec>")

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -1,13 +1,20 @@
 class CompilationEngine
   def initialize(input, output)
     @output = output
+    @tokenizer = JackTokenizer.new(input)
   end
 
   def compile_class
+    @output.puts("<class>")
+    @tokenizer.has_more_tokens?
+    @tokenizer.advance
+    @output.puts("  <keyword> class </keyword>")
+
+    @tokenizer.has_more_tokens?
+    @tokenizer.advance
+    @output.puts("  <identifier> #{@tokenizer.identifier} </identifier>")
+
     @output.puts <<~HEREDOC
-      <class>
-        <keyword> class </keyword>
-        <identifier> Foo </identifier>
         <symbol> { </symbol>
         <symbol> } </symbol>
       </class>

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -6,18 +6,29 @@ class CompilationEngine
 
   def compile_class
     @output.puts("<class>")
-    @tokenizer.has_more_tokens?
-    @tokenizer.advance
+    @tokenizer.has_more_tokens? && @tokenizer.advance
     @output.puts("  <keyword> class </keyword>")
 
-    @tokenizer.has_more_tokens?
-    @tokenizer.advance
+    @tokenizer.has_more_tokens? && @tokenizer.advance
     @output.puts("  <identifier> #{@tokenizer.identifier} </identifier>")
 
-    @output.puts <<~HEREDOC
-        <symbol> { </symbol>
-        <symbol> } </symbol>
-      </class>
-    HEREDOC
+    @tokenizer.has_more_tokens? && @tokenizer.advance
+    @output.puts("  <symbol> { </symbol>")
+
+    @tokenizer.has_more_tokens? && @tokenizer.advance
+    if @tokenizer.token_type == :KEYWORD
+      @output.puts <<~HEREDOC
+        \s\s<classVarDec>
+        \s\s\s\s<keyword> field </keyword>
+        \s\s\s\s<keyword> int </keyword>
+        \s\s\s\s<identifier> bloop </identifier>
+        \s\s\s\s<symbol> ; </symbol>
+        \s\s</classVarDec>
+      HEREDOC
+    end
+
+    @tokenizer.has_more_tokens? && @tokenizer.advance
+    @output.puts("  <symbol> } </symbol>")
+    @output.puts("</class>")
   end
 end

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -17,18 +17,22 @@ class CompilationEngine
 
     @tokenizer.has_more_tokens? && @tokenizer.advance
     if @tokenizer.token_type == :KEYWORD
-      @output.puts <<~HEREDOC
-        <classVarDec>
-        <keyword> field </keyword>
-        <keyword> int </keyword>
-        <identifier> bloop </identifier>
-        <symbol> ; </symbol>
-        </classVarDec>
-      HEREDOC
+      compile_class_var_dec
     end
 
     @tokenizer.has_more_tokens? && @tokenizer.advance
     @output.puts("<symbol> } </symbol>")
     @output.puts("</class>")
+  end
+
+  def compile_class_var_dec
+    @output.puts <<~HEREDOC
+      <classVarDec>
+      <keyword> field </keyword>
+      <keyword> int </keyword>
+      <identifier> bloop </identifier>
+      <symbol> ; </symbol>
+      </classVarDec>
+    HEREDOC
   end
 end

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -1,0 +1,16 @@
+class CompilationEngine
+  def initialize(input, output)
+    @output = output
+  end
+
+  def compile_class
+    @output.puts <<~HEREDOC
+      <class>
+        <keyword> class </keyword>
+        <identifier> Foo </identifier>
+        <symbol> { </symbol>
+        <symbol> } </symbol>
+      </class>
+    HEREDOC
+  end
+end

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -7,28 +7,28 @@ class CompilationEngine
   def compile_class
     @output.puts("<class>")
     @tokenizer.has_more_tokens? && @tokenizer.advance
-    @output.puts("  <keyword> class </keyword>")
+    @output.puts("<keyword> class </keyword>")
 
     @tokenizer.has_more_tokens? && @tokenizer.advance
-    @output.puts("  <identifier> #{@tokenizer.identifier} </identifier>")
+    @output.puts("<identifier> #{@tokenizer.identifier} </identifier>")
 
     @tokenizer.has_more_tokens? && @tokenizer.advance
-    @output.puts("  <symbol> { </symbol>")
+    @output.puts("<symbol> { </symbol>")
 
     @tokenizer.has_more_tokens? && @tokenizer.advance
     if @tokenizer.token_type == :KEYWORD
       @output.puts <<~HEREDOC
-        \s\s<classVarDec>
-        \s\s\s\s<keyword> field </keyword>
-        \s\s\s\s<keyword> int </keyword>
-        \s\s\s\s<identifier> bloop </identifier>
-        \s\s\s\s<symbol> ; </symbol>
-        \s\s</classVarDec>
+        <classVarDec>
+        <keyword> field </keyword>
+        <keyword> int </keyword>
+        <identifier> bloop </identifier>
+        <symbol> ; </symbol>
+        </classVarDec>
       HEREDOC
     end
 
     @tokenizer.has_more_tokens? && @tokenizer.advance
-    @output.puts("  <symbol> } </symbol>")
+    @output.puts("<symbol> } </symbol>")
     @output.puts("</class>")
   end
 end

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -1,7 +1,7 @@
 class CompilationEngine
-  def initialize(input, output)
+  def initialize(input, output, tokenizer: JackTokenizer.new(input))
     @output = output
-    @tokenizer = JackTokenizer.new(input)
+    @tokenizer = tokenizer
   end
 
   def compile_class

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -26,13 +26,11 @@ class CompilationEngine
   end
 
   def compile_class_var_dec
-    @output.puts <<~HEREDOC
-      <classVarDec>
-      <keyword> field </keyword>
-      <keyword> int </keyword>
-      <identifier> bloop </identifier>
-      <symbol> ; </symbol>
-      </classVarDec>
-    HEREDOC
+    @output.puts("<classVarDec>")
+    @output.puts("<keyword> #{@tokenizer.key_word.downcase.to_s} </keyword>")
+    @output.puts("<keyword> int </keyword>")
+    @output.puts("<identifier> bloop </identifier>")
+    @output.puts("<symbol> ; </symbol>")
+    @output.puts("</classVarDec>")
   end
 end

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -16,8 +16,10 @@ class CompilationEngine
     @output.puts("<symbol> #{@tokenizer.symbol} </symbol>")
 
     @tokenizer.has_more_tokens? && @tokenizer.advance
-    if @tokenizer.token_type == :KEYWORD
+    if [:STATIC, :FIELD].include?(@tokenizer.key_word)
       compile_class_var_dec
+    elsif [:CONSTRUCTOR, :FUNCTION, :METHOD, :VOID].include?(@tokenizer.key_word)
+      compile_subroutine
     end
 
     @tokenizer.has_more_tokens? && @tokenizer.advance
@@ -38,5 +40,9 @@ class CompilationEngine
     @tokenizer.has_more_tokens? && @tokenizer.advance
     @output.puts("<symbol> #{@tokenizer.symbol} </symbol>")
     @output.puts("</classVarDec>")
+  end
+
+  def compile_subroutine
+    raise NotImplementedError
   end
 end

--- a/test/unit/compilation_engine_test.rb
+++ b/test/unit/compilation_engine_test.rb
@@ -65,12 +65,38 @@ class CompilationEngineTest < Minitest::Test
   def test_compile_class_var_dec_for_field_variables
     input = StringIO.new("field int bloop")
     output = StringIO.new
-    compilation_engine = CompilationEngine.new(input, output)
+    tokenizer = JackTokenizer.new(input)
+    compilation_engine = CompilationEngine.new(input, output, tokenizer: tokenizer)
+
+    assert tokenizer.has_more_tokens?
+    tokenizer.advance
     compilation_engine.compile_class_var_dec
 
     expected = <<~HEREDOC
       <classVarDec>
       <keyword> field </keyword>
+      <keyword> int </keyword>
+      <identifier> bloop </identifier>
+      <symbol> ; </symbol>
+      </classVarDec>
+    HEREDOC
+
+    assert_equal(expected, output.string)
+  end
+
+  def test_compile_class_var_dec_for_static_variables
+    input = StringIO.new("static int bloop")
+    output = StringIO.new
+    tokenizer = JackTokenizer.new(input)
+    compilation_engine = CompilationEngine.new(input, output, tokenizer: tokenizer)
+
+    assert tokenizer.has_more_tokens?
+    tokenizer.advance
+    compilation_engine.compile_class_var_dec
+
+    expected = <<~HEREDOC
+      <classVarDec>
+      <keyword> static </keyword>
       <keyword> int </keyword>
       <identifier> bloop </identifier>
       <symbol> ; </symbol>

--- a/test/unit/compilation_engine_test.rb
+++ b/test/unit/compilation_engine_test.rb
@@ -61,4 +61,22 @@ class CompilationEngineTest < Minitest::Test
 
     assert_equal(expected, output.string)
   end
+
+  def test_compile_class_var_dec_for_field_variables
+    input = StringIO.new("field int bloop")
+    output = StringIO.new
+    compilation_engine = CompilationEngine.new(input, output)
+    compilation_engine.compile_class_var_dec
+
+    expected = <<~HEREDOC
+      <classVarDec>
+      <keyword> field </keyword>
+      <keyword> int </keyword>
+      <identifier> bloop </identifier>
+      <symbol> ; </symbol>
+      </classVarDec>
+    HEREDOC
+
+    assert_equal(expected, output.string)
+  end
 end

--- a/test/unit/compilation_engine_test.rb
+++ b/test/unit/compilation_engine_test.rb
@@ -37,4 +37,28 @@ class CompilationEngineTest < Minitest::Test
 
     assert_equal(expected, output.string)
   end
+
+  def test_compile_class_compiles_class_with_class_var_dec
+    input = StringIO.new("class Foo { field int bloop }")
+    output = StringIO.new
+    compilation_engine = CompilationEngine.new(input, output)
+    compilation_engine.compile_class
+
+    expected = <<~HEREDOC
+      <class>
+        <keyword> class </keyword>
+        <identifier> Foo </identifier>
+        <symbol> { </symbol>
+        <classVarDec>
+          <keyword> field </keyword>
+          <keyword> int </keyword>
+          <identifier> bloop </identifier>
+          <symbol> ; </symbol>
+        </classVarDec>
+        <symbol> } </symbol>
+      </class>
+    HEREDOC
+
+    assert_equal(expected, output.string)
+  end
 end

--- a/test/unit/compilation_engine_test.rb
+++ b/test/unit/compilation_engine_test.rb
@@ -19,4 +19,22 @@ class CompilationEngineTest < Minitest::Test
 
     assert_equal(expected, output.string)
   end
+
+  def test_compile_class_compiles_another_empty_class
+    input = StringIO.new("class Bar { }")
+    output = StringIO.new
+    compilation_engine = CompilationEngine.new(input, output)
+    compilation_engine.compile_class
+
+    expected = <<~HEREDOC
+      <class>
+        <keyword> class </keyword>
+        <identifier> Bar </identifier>
+        <symbol> { </symbol>
+        <symbol> } </symbol>
+      </class>
+    HEREDOC
+
+    assert_equal(expected, output.string)
+  end
 end

--- a/test/unit/compilation_engine_test.rb
+++ b/test/unit/compilation_engine_test.rb
@@ -105,4 +105,26 @@ class CompilationEngineTest < Minitest::Test
 
     assert_equal(expected, output.string)
   end
+
+  def test_compile_class_var_dec_for_static_variables_different_type
+    input = StringIO.new("static boolean bloop")
+    output = StringIO.new
+    tokenizer = JackTokenizer.new(input)
+    compilation_engine = CompilationEngine.new(input, output, tokenizer: tokenizer)
+
+    assert tokenizer.has_more_tokens?
+    tokenizer.advance
+    compilation_engine.compile_class_var_dec
+
+    expected = <<~HEREDOC
+      <classVarDec>
+      <keyword> static </keyword>
+      <keyword> boolean </keyword>
+      <identifier> bloop </identifier>
+      <symbol> ; </symbol>
+      </classVarDec>
+    HEREDOC
+
+    assert_equal(expected, output.string)
+  end
 end

--- a/test/unit/compilation_engine_test.rb
+++ b/test/unit/compilation_engine_test.rb
@@ -127,4 +127,26 @@ class CompilationEngineTest < Minitest::Test
 
     assert_equal(expected, output.string)
   end
+
+  def test_compile_class_var_dec_for_static_variables_different_type
+    input = StringIO.new("static boolean bleep")
+    output = StringIO.new
+    tokenizer = JackTokenizer.new(input)
+    compilation_engine = CompilationEngine.new(input, output, tokenizer: tokenizer)
+
+    assert tokenizer.has_more_tokens?
+    tokenizer.advance
+    compilation_engine.compile_class_var_dec
+
+    expected = <<~HEREDOC
+      <classVarDec>
+      <keyword> static </keyword>
+      <keyword> boolean </keyword>
+      <identifier> bleep </identifier>
+      <symbol> ; </symbol>
+      </classVarDec>
+    HEREDOC
+
+    assert_equal(expected, output.string)
+  end
 end

--- a/test/unit/compilation_engine_test.rb
+++ b/test/unit/compilation_engine_test.rb
@@ -10,10 +10,10 @@ class CompilationEngineTest < Minitest::Test
 
     expected = <<~HEREDOC
       <class>
-        <keyword> class </keyword>
-        <identifier> Foo </identifier>
-        <symbol> { </symbol>
-        <symbol> } </symbol>
+      <keyword> class </keyword>
+      <identifier> Foo </identifier>
+      <symbol> { </symbol>
+      <symbol> } </symbol>
       </class>
     HEREDOC
 
@@ -28,10 +28,10 @@ class CompilationEngineTest < Minitest::Test
 
     expected = <<~HEREDOC
       <class>
-        <keyword> class </keyword>
-        <identifier> Bar </identifier>
-        <symbol> { </symbol>
-        <symbol> } </symbol>
+      <keyword> class </keyword>
+      <identifier> Bar </identifier>
+      <symbol> { </symbol>
+      <symbol> } </symbol>
       </class>
     HEREDOC
 
@@ -46,16 +46,16 @@ class CompilationEngineTest < Minitest::Test
 
     expected = <<~HEREDOC
       <class>
-        <keyword> class </keyword>
-        <identifier> Foo </identifier>
-        <symbol> { </symbol>
-        <classVarDec>
-          <keyword> field </keyword>
-          <keyword> int </keyword>
-          <identifier> bloop </identifier>
-          <symbol> ; </symbol>
-        </classVarDec>
-        <symbol> } </symbol>
+      <keyword> class </keyword>
+      <identifier> Foo </identifier>
+      <symbol> { </symbol>
+      <classVarDec>
+      <keyword> field </keyword>
+      <keyword> int </keyword>
+      <identifier> bloop </identifier>
+      <symbol> ; </symbol>
+      </classVarDec>
+      <symbol> } </symbol>
       </class>
     HEREDOC
 

--- a/test/unit/compilation_engine_test.rb
+++ b/test/unit/compilation_engine_test.rb
@@ -39,7 +39,7 @@ class CompilationEngineTest < Minitest::Test
   end
 
   def test_compile_class_compiles_class_with_class_var_dec
-    input = StringIO.new("class Foo { field int bloop }")
+    input = StringIO.new("class Foo { field int bloop; }")
     output = StringIO.new
     compilation_engine = CompilationEngine.new(input, output)
     compilation_engine.compile_class
@@ -63,7 +63,7 @@ class CompilationEngineTest < Minitest::Test
   end
 
   def test_compile_class_var_dec_for_field_variables
-    input = StringIO.new("field int bloop")
+    input = StringIO.new("field int bloop;")
     output = StringIO.new
     tokenizer = JackTokenizer.new(input)
     compilation_engine = CompilationEngine.new(input, output, tokenizer: tokenizer)
@@ -85,7 +85,7 @@ class CompilationEngineTest < Minitest::Test
   end
 
   def test_compile_class_var_dec_for_static_variables
-    input = StringIO.new("static int bloop")
+    input = StringIO.new("static int bloop;")
     output = StringIO.new
     tokenizer = JackTokenizer.new(input)
     compilation_engine = CompilationEngine.new(input, output, tokenizer: tokenizer)
@@ -107,6 +107,7 @@ class CompilationEngineTest < Minitest::Test
   end
 
   def test_compile_class_var_dec_for_different_variable_type
+    input = StringIO.new("static boolean bloop;")
     output = StringIO.new
     tokenizer = JackTokenizer.new(input)
     compilation_engine = CompilationEngine.new(input, output, tokenizer: tokenizer)
@@ -128,6 +129,7 @@ class CompilationEngineTest < Minitest::Test
   end
 
   def test_compile_class_var_dec_for_different_variable_name
+    input = StringIO.new("static boolean bleep;")
     output = StringIO.new
     tokenizer = JackTokenizer.new(input)
     compilation_engine = CompilationEngine.new(input, output, tokenizer: tokenizer)

--- a/test/unit/compilation_engine_test.rb
+++ b/test/unit/compilation_engine_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+require "compilation_engine"
+
+class CompilationEngineTest < Minitest::Test
+  def test_compile_class_compiles_empty_class
+    input = StringIO.new("class Foo { }")
+    output = StringIO.new
+    compilation_engine = CompilationEngine.new(input, output)
+    compilation_engine.compile_class
+
+    expected = <<~HEREDOC
+      <class>
+        <keyword> class </keyword>
+        <identifier> Foo </identifier>
+        <symbol> { </symbol>
+        <symbol> } </symbol>
+      </class>
+    HEREDOC
+
+    assert_equal(expected, output.string)
+  end
+end

--- a/test/unit/compilation_engine_test.rb
+++ b/test/unit/compilation_engine_test.rb
@@ -106,8 +106,7 @@ class CompilationEngineTest < Minitest::Test
     assert_equal(expected, output.string)
   end
 
-  def test_compile_class_var_dec_for_static_variables_different_type
-    input = StringIO.new("static boolean bloop")
+  def test_compile_class_var_dec_for_different_variable_type
     output = StringIO.new
     tokenizer = JackTokenizer.new(input)
     compilation_engine = CompilationEngine.new(input, output, tokenizer: tokenizer)
@@ -128,8 +127,7 @@ class CompilationEngineTest < Minitest::Test
     assert_equal(expected, output.string)
   end
 
-  def test_compile_class_var_dec_for_static_variables_different_type
-    input = StringIO.new("static boolean bleep")
+  def test_compile_class_var_dec_for_different_variable_name
     output = StringIO.new
     tokenizer = JackTokenizer.new(input)
     compilation_engine = CompilationEngine.new(input, output, tokenizer: tokenizer)


### PR DESCRIPTION
# Changes
- Start to implement `#compile_class` that leads into `#compile_class_var_dec` 
- Set the stage for the next method, `#compile_subroutine`

I made the decision to make the tokenizer an optional keyword argument. If it's not specified, a tokenizer will be created within the initialize method. We want to have access to our own tokenizer in order to individually test each `#compile_xxx` method.