### PR TITLE
Introduce acceptance tests and run them on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,12 @@ jobs:
         with:
           java-version: 11
           distribution: adopt
+      - name: Download the nand2tetris tools
+        run: |
+          curl --location --output nand2tetris.zip 'https://drive.google.com/uc?id=1xZzcMIUETv3u3sdpM_oTJSTetpVee3KZ&export=download'
+          unzip nand2tetris.zip
+          chmod a+x nand2tetris/tools/*.sh
       - name: Run tests
         run: bundle exec rake test
+        env:
+          TEXT_COMPARER: nand2tetris/tools/TextComparer.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,5 @@ jobs:
         with:
           java-version: 11
           distribution: adopt
-      - uses: actions/cache@v2
-        id: cache-nand2tetris
-        with:
-          path: nand2tetris
-          key: nand2tetris
       - name: Run tests
         run: bundle exec rake test

--- a/test/acceptance/jack_analyzer_test.rb
+++ b/test/acceptance/jack_analyzer_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+require "tempfile"
+
+class JackAnalyzerAcceptanceTest < Minitest::Test
+  TEXT_COMPARER_PATH = ENV["TEXT_COMPARER"]
+
+  Dir.glob("ExpressionLessSquare/*.jack", base: "examples").each do |file_name|
+    base_name = File.join(File.dirname(file_name), File.basename(file_name, ".*"))
+    expected_xml_path = File.join("test/expected", "#{base_name}.xml")
+    test_name = "test_acceptance_#{base_name}"
+
+    define_method(test_name) do
+      skip "can’t find text comparer, please set TEXT_COMPARER" unless TEXT_COMPARER_PATH
+
+      # make a temporary file
+      Tempfile.create do |actual_xml_file|
+        # parse .jack and write the resulting XML into the temporary file
+        actual_xml = `bin/jack_analyzer examples/#{base_name}.jack`
+        actual_xml_file.write(actual_xml)
+        actual_xml_file.close
+
+        # run the text comparer and remember its exit status
+        text_comparer_exit_status = nil
+        text_comparer_output, _text_comparer_error = capture_subprocess_io do
+          text_comparer_exit_status = system(TEXT_COMPARER_PATH, expected_xml_path, actual_xml_file.path)
+        end
+
+        # check that the exit status was `true` (i.e. success)
+        assert(text_comparer_exit_status, text_comparer_output)
+      end
+    end
+  end
+end


### PR DESCRIPTION
In the same vein as wildmaples/jack-virtual-machine#4, we can use the example `ExpressionLessSquare` Jack programs and XML files to automatically generate acceptance tests for the `bin/jack_analyzer` script.

I’ve had to disable the GitHub Actions cache for `nand2tetris.zip` because it was (accidentally) already enabled and therefore caching an empty directory, which means CI currently downloads a fresh `nand2tetris.zip` each time. It’s not a big deal but we should turn the cache on again after this has been merged.