### PR TITLE
Complete the parser!!!!!! (that only emits XML btw) 

### DIFF
--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -243,6 +243,10 @@ class CompilationEngine
         output_token # [
         compile_expression
         output_token # ]
+      elsif symbol_token?("(")
+        output_token # (
+        compile_expression_list
+        output_token # )
       end
     end
 

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -194,7 +194,7 @@ class CompilationEngine
     @output.puts("<expression>")
     compile_term
 
-    if symbol_token?(*OP_SYMBOLS)
+    while symbol_token?(*OP_SYMBOLS)
       output_token # op symbol
       compile_term
     end

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -281,8 +281,8 @@ class CompilationEngine
     advance
   end
 
-  def symbol_token?(symbol)
-    @tokenizer.token_type == :SYMBOL && @tokenizer.symbol == symbol
+  def symbol_token?(*symbols)
+    @tokenizer.token_type == :SYMBOL && symbols.include?(@tokenizer.symbol)
   end
 
   def keyword_token?(keyword = nil)

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -232,6 +232,12 @@ class CompilationEngine
       compile_term
     else
       output_token # int / str / keyword / identifier / subroutine call / expression
+
+      if symbol_token?("[")
+        output_token # [
+        compile_expression
+        output_token # ]
+      end
     end
 
     @output.puts("</term>")

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -231,7 +231,7 @@ class CompilationEngine
       output_token # unary op
       compile_term
     else
-      output_token # int / str / keyword / identifier / subroutine call / expression / unary op
+      output_token # int / str / keyword / identifier / subroutine call / expression
     end
 
     @output.puts("</term>")

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -227,7 +227,7 @@ class CompilationEngine
   def compile_term
     @output.puts("<term>")
 
-    if symbol_token?(*["-", "~"])
+    if symbol_token?("-", "~")
       output_token # unary op
       compile_term
 

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -188,9 +188,17 @@ class CompilationEngine
     @output.puts("</ifStatement>")
   end
 
+  OP_SYMBOLS = %w[+ - * / & | < > =]
+
   def compile_expression
     @output.puts("<expression>")
     compile_term
+
+    if symbol_token?(*OP_SYMBOLS)
+      output_token # op symbol
+      compile_term
+    end
+
     @output.puts("</expression>")
   end
 

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -237,13 +237,21 @@ class CompilationEngine
       output_token # )
 
     else
-      output_token # int / str / keyword / identifier
+      output_token # int / str / keyword / identifier / start of a subroutine call
 
       if symbol_token?("[")
         output_token # [
         compile_expression
         output_token # ]
+
       elsif symbol_token?("(")
+        output_token # (
+        compile_expression_list
+        output_token # )
+
+      elsif symbol_token?(".")
+        output_token # .
+        output_token # subroutineName
         output_token # (
         compile_expression_list
         output_token # )

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -226,7 +226,14 @@ class CompilationEngine
 
   def compile_term
     @output.puts("<term>")
-    output_token # int / str / keyword / identifier / subroutine call / expression / unary op
+
+    if symbol_token?(*["-", "~"])
+      output_token # unary op
+      compile_term
+    else
+      output_token # int / str / keyword / identifier / subroutine call / expression / unary op
+    end
+
     @output.puts("</term>")
   end
 

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -230,8 +230,14 @@ class CompilationEngine
     if symbol_token?(*["-", "~"])
       output_token # unary op
       compile_term
+
+    elsif symbol_token?("(")
+      output_token # (
+      compile_expression
+      output_token # )
+
     else
-      output_token # int / str / keyword / identifier / subroutine call / expression
+      output_token # int / str / keyword / identifier
 
       if symbol_token?("[")
         output_token # [

--- a/lib/jack_tokenizer.rb
+++ b/lib/jack_tokenizer.rb
@@ -7,7 +7,7 @@ class JackTokenizer
   KEYWORD_TOKENS = %w[class method function constructor int boolean char void var static field let do if else while return true false null this]
 
   def has_more_tokens?
-    if (match = @input.match(%r{([ \n\r\t]+|//.*$|/\*(.|\n)*\*/)+}, @index)) && match.begin(0) == @index
+    if (match = @input.match(%r{([ \n\r\t]+|//.*$|/\*(.|\n)*?\*/)+}, @index)) && match.begin(0) == @index
       @index = match.end(0)
     end
 

--- a/test/acceptance/jack_analyzer_test.rb
+++ b/test/acceptance/jack_analyzer_test.rb
@@ -4,7 +4,7 @@ require "tempfile"
 class JackAnalyzerAcceptanceTest < Minitest::Test
   TEXT_COMPARER_PATH = ENV["TEXT_COMPARER"]
 
-  Dir.glob("ExpressionLessSquare/*.jack", base: "examples").each do |file_name|
+  Dir.glob("*/*.jack", base: "examples").each do |file_name|
     base_name = File.join(File.dirname(file_name), File.basename(file_name, ".*"))
     expected_xml_path = File.join("test/expected", "#{base_name}.xml")
     test_name = "test_acceptance_#{base_name}"

--- a/test/acceptance/tokenizer_test.rb
+++ b/test/acceptance/tokenizer_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+require "tempfile"
+
+class TokenizerAcceptanceTest < Minitest::Test
+  TEXT_COMPARER_PATH = ENV["TEXT_COMPARER"]
+
+  Dir.glob("*/*.jack", base: "examples").each do |file_name|
+    base_name = File.join(File.dirname(file_name), File.basename(file_name, ".*"))
+    expected_xml_path = File.join("test/expected", "#{base_name}T.xml")
+    test_name = "test_acceptance_#{base_name}"
+
+    define_method(test_name) do
+      skip "can’t find text comparer, please set TEXT_COMPARER" unless TEXT_COMPARER_PATH
+
+      # make a temporary file
+      Tempfile.create do |actual_xml_file|
+        # tokenize .jack and write the resulting XML into the temporary file
+        actual_xml = `bin/tokenizer examples/#{base_name}.jack`
+        actual_xml_file.write(actual_xml)
+        actual_xml_file.close
+
+        # run the text comparer and remember its exit status
+        text_comparer_exit_status = nil
+        text_comparer_output, _text_comparer_error = capture_subprocess_io do
+          text_comparer_exit_status = system(TEXT_COMPARER_PATH, expected_xml_path, actual_xml_file.path)
+        end
+
+        # check that the exit status was `true` (i.e. success)
+        assert(text_comparer_exit_status, text_comparer_output)
+      end
+    end
+  end
+end

--- a/test/unit/compilation_engine_test.rb
+++ b/test/unit/compilation_engine_test.rb
@@ -1149,7 +1149,7 @@ class CompilationEngineTest < Minitest::Test
     assert_equal(expected, output.string)
   end
 
-  def test_compile_term_subroutine_call
+  def test_compile_term_subroutine_call_by_class_or_var
     input = StringIO.new("bloop.send()")
     output = StringIO.new
     tokenizer = JackTokenizer.new(input)

--- a/test/unit/compilation_engine_test.rb
+++ b/test/unit/compilation_engine_test.rb
@@ -1075,6 +1075,32 @@ class CompilationEngineTest < Minitest::Test
     assert_equal(expected, output.string)
   end
 
+  def test_compile_term_array_index
+    input = StringIO.new("bloop[99]")
+    output = StringIO.new
+    tokenizer = JackTokenizer.new(input)
+    compilation_engine = CompilationEngine.new(input, output, tokenizer: tokenizer)
+
+    assert tokenizer.has_more_tokens?
+    tokenizer.advance
+    compilation_engine.compile_term
+
+    expected = <<~HEREDOC
+      <term>
+      <identifier> bloop </identifier>
+      <symbol> [ </symbol>
+      <expression>
+      <term>
+      <integerConstant> 99 </integerConstant>
+      </term>
+      </expression>
+      <symbol> ] </symbol>
+      </term>
+    HEREDOC
+
+    assert_equal(expected, output.string)
+  end
+
   def test_compile_expression_of_single_term
     input = StringIO.new("foo")
     output = StringIO.new

--- a/test/unit/compilation_engine_test.rb
+++ b/test/unit/compilation_engine_test.rb
@@ -1126,6 +1126,29 @@ class CompilationEngineTest < Minitest::Test
     assert_equal(expected, output.string)
   end
 
+  def test_compile_term_subroutine_call
+    input = StringIO.new("bloop()")
+    output = StringIO.new
+    tokenizer = JackTokenizer.new(input)
+    compilation_engine = CompilationEngine.new(input, output, tokenizer: tokenizer)
+
+    assert tokenizer.has_more_tokens?
+    tokenizer.advance
+    compilation_engine.compile_term
+
+    expected = <<~HEREDOC
+      <term>
+      <identifier> bloop </identifier>
+      <symbol> ( </symbol>
+      <expressionList>
+      </expressionList>
+      <symbol> ) </symbol>
+      </term>
+    HEREDOC
+
+    assert_equal(expected, output.string)
+  end
+
   def test_compile_expression_of_single_term
     input = StringIO.new("foo")
     output = StringIO.new

--- a/test/unit/compilation_engine_test.rb
+++ b/test/unit/compilation_engine_test.rb
@@ -1101,6 +1101,31 @@ class CompilationEngineTest < Minitest::Test
     assert_equal(expected, output.string)
   end
 
+  def test_compile_term_expression
+    input = StringIO.new("(0)")
+    output = StringIO.new
+    tokenizer = JackTokenizer.new(input)
+    compilation_engine = CompilationEngine.new(input, output, tokenizer: tokenizer)
+
+    assert tokenizer.has_more_tokens?
+    tokenizer.advance
+    compilation_engine.compile_term
+
+    expected = <<~HEREDOC
+      <term>
+      <symbol> ( </symbol>
+      <expression>
+      <term>
+      <integerConstant> 0 </integerConstant>
+      </term>
+      </expression>
+      <symbol> ) </symbol>
+      </term>
+    HEREDOC
+
+    assert_equal(expected, output.string)
+  end
+
   def test_compile_expression_of_single_term
     input = StringIO.new("foo")
     output = StringIO.new

--- a/test/unit/compilation_engine_test.rb
+++ b/test/unit/compilation_engine_test.rb
@@ -1098,4 +1098,33 @@ class CompilationEngineTest < Minitest::Test
 
     assert_equal(expected, output.string)
   end
+
+  def test_compile_expression_of_terms_with_multiple_operations
+    input = StringIO.new("1 + 2 - 3")
+    output = StringIO.new
+    tokenizer = JackTokenizer.new(input)
+    compilation_engine = CompilationEngine.new(input, output, tokenizer: tokenizer)
+
+    assert tokenizer.has_more_tokens?
+    tokenizer.advance
+    compilation_engine.compile_expression
+
+    expected = <<~HEREDOC
+      <expression>
+      <term>
+      <integerConstant> 1 </integerConstant>
+      </term>
+      <symbol> + </symbol>
+      <term>
+      <integerConstant> 2 </integerConstant>
+      </term>
+      <symbol> - </symbol>
+      <term>
+      <integerConstant> 3 </integerConstant>
+      </term>
+      </expression>
+    HEREDOC
+
+    assert_equal(expected, output.string)
+  end
 end

--- a/test/unit/compilation_engine_test.rb
+++ b/test/unit/compilation_engine_test.rb
@@ -1053,6 +1053,28 @@ class CompilationEngineTest < Minitest::Test
     assert_equal(expected, output.string)
   end
 
+  def test_compile_term_unary_op
+    input = StringIO.new("-1")
+    output = StringIO.new
+    tokenizer = JackTokenizer.new(input)
+    compilation_engine = CompilationEngine.new(input, output, tokenizer: tokenizer)
+
+    assert tokenizer.has_more_tokens?
+    tokenizer.advance
+    compilation_engine.compile_term
+
+    expected = <<~HEREDOC
+      <term>
+      <symbol> - </symbol>
+      <term>
+      <integerConstant> 1 </integerConstant>
+      </term>
+      </term>
+    HEREDOC
+
+    assert_equal(expected, output.string)
+  end
+
   def test_compile_expression_of_single_term
     input = StringIO.new("foo")
     output = StringIO.new

--- a/test/unit/compilation_engine_test.rb
+++ b/test/unit/compilation_engine_test.rb
@@ -1149,6 +1149,31 @@ class CompilationEngineTest < Minitest::Test
     assert_equal(expected, output.string)
   end
 
+  def test_compile_term_subroutine_call
+    input = StringIO.new("bloop.send()")
+    output = StringIO.new
+    tokenizer = JackTokenizer.new(input)
+    compilation_engine = CompilationEngine.new(input, output, tokenizer: tokenizer)
+
+    assert tokenizer.has_more_tokens?
+    tokenizer.advance
+    compilation_engine.compile_term
+
+    expected = <<~HEREDOC
+      <term>
+      <identifier> bloop </identifier>
+      <symbol> . </symbol>
+      <identifier> send </identifier>
+      <symbol> ( </symbol>
+      <expressionList>
+      </expressionList>
+      <symbol> ) </symbol>
+      </term>
+    HEREDOC
+
+    assert_equal(expected, output.string)
+  end
+
   def test_compile_expression_of_single_term
     input = StringIO.new("foo")
     output = StringIO.new

--- a/test/unit/compilation_engine_test.rb
+++ b/test/unit/compilation_engine_test.rb
@@ -1053,7 +1053,7 @@ class CompilationEngineTest < Minitest::Test
     assert_equal(expected, output.string)
   end
 
-  def test_compile_expression_of_single_expression
+  def test_compile_expression_of_single_term
     input = StringIO.new("foo")
     output = StringIO.new
     tokenizer = JackTokenizer.new(input)
@@ -1067,6 +1067,31 @@ class CompilationEngineTest < Minitest::Test
       <expression>
       <term>
       <identifier> foo </identifier>
+      </term>
+      </expression>
+    HEREDOC
+
+    assert_equal(expected, output.string)
+  end
+
+  def test_compile_expression_of_terms_with_operation
+    input = StringIO.new("1 + 1")
+    output = StringIO.new
+    tokenizer = JackTokenizer.new(input)
+    compilation_engine = CompilationEngine.new(input, output, tokenizer: tokenizer)
+
+    assert tokenizer.has_more_tokens?
+    tokenizer.advance
+    compilation_engine.compile_expression
+
+    expected = <<~HEREDOC
+      <expression>
+      <term>
+      <integerConstant> 1 </integerConstant>
+      </term>
+      <symbol> + </symbol>
+      <term>
+      <integerConstant> 1 </integerConstant>
       </term>
       </expression>
     HEREDOC

--- a/test/unit/jack_tokenizer_test.rb
+++ b/test/unit/jack_tokenizer_test.rb
@@ -103,7 +103,7 @@ class JackTokenizerTest < Minitest::Test
   end
 
   def test_has_more_tokens_skips_multiple_comments
-    io = StringIO.new("/* TODO xyz[123] */ \n // lol")
+    io = StringIO.new("/* TODO xyz[123] */\n // lol")
     jack_tokenizer = JackTokenizer.new(io)
     refute(jack_tokenizer.has_more_tokens?)
   end
@@ -111,6 +111,16 @@ class JackTokenizerTest < Minitest::Test
   def test_has_more_tokens_skips_double_asterisk_comment
     io = StringIO.new("/** TODO xyz[123] */")
     jack_tokenizer = JackTokenizer.new(io)
+    refute(jack_tokenizer.has_more_tokens?)
+  end
+
+  def test_has_more_tokens_skips_double_asterisk_comment_twice
+    io = StringIO.new("/** TODO xyz[123] */\nxyz[123] /** another TODO */ ")
+    jack_tokenizer = JackTokenizer.new(io)
+    4.times do
+      assert(jack_tokenizer.has_more_tokens?)
+      jack_tokenizer.advance
+    end
     refute(jack_tokenizer.has_more_tokens?)
   end
 


### PR DESCRIPTION
# Changes

- The parser works! Implement op and unary op in `#compile_expression`, and complete `#compile_term`
- Fix the regexp bug that skips all the code in between double asterisk comments. It was greedy (by default), matching the maximum amount of characters in between the comment notation, so we switched it to lazy. 
- Unlock all acceptance tests, proving to the world that the parser indeed works
- Did I mention the parser works 