### PR TITLE
Create SymbolTable to store identifiers and their properties

### DIFF
--- a/lib/symbol_table.rb
+++ b/lib/symbol_table.rb
@@ -29,6 +29,10 @@ class SymbolTable
     symbol_table.values.count { |entry| entry[:kind] == kind }
   end
 
+  def start_subroutine
+    @subroutine_symbol_table = {}
+  end
+
   private
 
   def symbol_table

--- a/lib/symbol_table.rb
+++ b/lib/symbol_table.rb
@@ -4,14 +4,14 @@ class SymbolTable
   end
 
   def define(name, type, kind)
-    @symbol_table[name] = [type, kind]
+    @symbol_table[name] = {type: type, kind: kind}
   end
 
   def kind_of(name)
-    @symbol_table[name][1]
+    @symbol_table[name][:kind]
   end
 
   def type_of(name)
-    @symbol_table[name][0]
+    @symbol_table[name][:type]
   end
 end

--- a/lib/symbol_table.rb
+++ b/lib/symbol_table.rb
@@ -20,6 +20,6 @@ class SymbolTable
   end
 
   def var_count(kind)
-    @symbol_table.size
+    @symbol_table.values.count { |entry| entry[:kind] == kind }
   end
 end

--- a/lib/symbol_table.rb
+++ b/lib/symbol_table.rb
@@ -14,7 +14,7 @@ class SymbolTable
   end
 
   def kind_of(name)
-    symbol_table[name][:kind]
+    symbol_table.fetch(name, {kind: :NONE})[:kind]
   end
 
   def type_of(name)

--- a/lib/symbol_table.rb
+++ b/lib/symbol_table.rb
@@ -1,0 +1,13 @@
+class SymbolTable
+  def initialize
+    @symbol_table = {}
+  end
+
+  def define(name, type, kind)
+    @symbol_table[name] = kind
+  end
+
+  def kind_of(name)
+    @symbol_table[name]
+  end
+end

--- a/lib/symbol_table.rb
+++ b/lib/symbol_table.rb
@@ -4,10 +4,14 @@ class SymbolTable
   end
 
   def define(name, type, kind)
-    @symbol_table[name] = kind
+    @symbol_table[name] = [type, kind]
   end
 
   def kind_of(name)
-    @symbol_table[name]
+    @symbol_table[name][1]
+  end
+
+  def type_of(name)
+    @symbol_table[name][0]
   end
 end

--- a/lib/symbol_table.rb
+++ b/lib/symbol_table.rb
@@ -18,4 +18,8 @@ class SymbolTable
   def index_of(name)
     @symbol_table[name][:index]
   end
+
+  def var_count(kind)
+    @symbol_table.size
+  end
 end

--- a/lib/symbol_table.rb
+++ b/lib/symbol_table.rb
@@ -4,7 +4,7 @@ class SymbolTable
   end
 
   def define(name, type, kind)
-    @symbol_table[name] = {type: type, kind: kind}
+    @symbol_table[name] = {type: type, kind: kind, index: 0}
   end
 
   def kind_of(name)
@@ -13,5 +13,9 @@ class SymbolTable
 
   def type_of(name)
     @symbol_table[name][:type]
+  end
+
+  def index_of(name)
+    @symbol_table[name][:index]
   end
 end

--- a/lib/symbol_table.rb
+++ b/lib/symbol_table.rb
@@ -1,12 +1,16 @@
 class SymbolTable
   def initialize
-    @symbol_table = {}
+    @class_symbol_table = {}
+    @subroutine_symbol_table = {}
   end
 
-  attr_reader :symbol_table
-
   def define(name, type, kind)
-    symbol_table[name] = {type: type, kind: kind, index: var_count(kind)}
+    case kind
+    when :STATIC, :FIELD
+      @class_symbol_table[name] = {type: type, kind: kind, index: var_count(kind)}
+    when :ARG, :VAR
+      @subroutine_symbol_table[name] = {type: type, kind: kind, index: var_count(kind)}
+    end
   end
 
   def kind_of(name)
@@ -23,5 +27,11 @@ class SymbolTable
 
   def var_count(kind)
     symbol_table.values.count { |entry| entry[:kind] == kind }
+  end
+
+  private
+
+  def symbol_table
+    @subroutine_symbol_table.merge(@class_symbol_table)
   end
 end

--- a/lib/symbol_table.rb
+++ b/lib/symbol_table.rb
@@ -7,14 +7,14 @@ class SymbolTable
   def define(name, type, kind)
     case kind
     when :STATIC, :FIELD
-      @class_symbol_table[name] = {type: type, kind: kind, index: var_count(kind)}
+      @class_symbol_table[name] = { type: type, kind: kind, index: var_count(kind) }
     when :ARG, :VAR
-      @subroutine_symbol_table[name] = {type: type, kind: kind, index: var_count(kind)}
+      @subroutine_symbol_table[name] = { type: type, kind: kind, index: var_count(kind) }
     end
   end
 
   def kind_of(name)
-    symbol_table.fetch(name, {kind: :NONE})[:kind]
+    symbol_table.fetch(name, { kind: :NONE })[:kind]
   end
 
   def type_of(name)

--- a/lib/symbol_table.rb
+++ b/lib/symbol_table.rb
@@ -3,23 +3,25 @@ class SymbolTable
     @symbol_table = {}
   end
 
+  attr_reader :symbol_table
+
   def define(name, type, kind)
-    @symbol_table[name] = {type: type, kind: kind, index: var_count(kind)}
+    symbol_table[name] = {type: type, kind: kind, index: var_count(kind)}
   end
 
   def kind_of(name)
-    @symbol_table[name][:kind]
+    symbol_table[name][:kind]
   end
 
   def type_of(name)
-    @symbol_table[name][:type]
+    symbol_table[name][:type]
   end
 
   def index_of(name)
-    @symbol_table[name][:index]
+    symbol_table[name][:index]
   end
 
   def var_count(kind)
-    @symbol_table.values.count { |entry| entry[:kind] == kind }
+    symbol_table.values.count { |entry| entry[:kind] == kind }
   end
 end

--- a/lib/symbol_table.rb
+++ b/lib/symbol_table.rb
@@ -4,7 +4,7 @@ class SymbolTable
   end
 
   def define(name, type, kind)
-    @symbol_table[name] = {type: type, kind: kind, index: 0}
+    @symbol_table[name] = {type: type, kind: kind, index: var_count(kind)}
   end
 
   def kind_of(name)

--- a/test/unit/symbol_table_test.rb
+++ b/test/unit/symbol_table_test.rb
@@ -48,4 +48,20 @@ class SymbolTableTest < Minitest::Test
     assert_equal(2, symbol_table.var_count(:STATIC))
     assert_equal(1, symbol_table.var_count(:FIELD))
   end
+
+  def test_start_subroutine_resets_subroutine_scoped_identifiers
+    symbol_table = SymbolTable.new
+    symbol_table.define("too", "boolean", :ARG)
+    symbol_table.define("foo", "int", :STATIC)
+    symbol_table.define("bar", "boolean", :STATIC)
+    symbol_table.define("tar", "int", :ARG)
+
+    assert_equal(2, symbol_table.var_count(:ARG))
+    assert_equal(2, symbol_table.var_count(:STATIC))
+
+    symbol_table.start_subroutine
+    
+    assert_equal(0, symbol_table.var_count(:ARG))
+    assert_equal(2, symbol_table.var_count(:STATIC))
+  end
 end

--- a/test/unit/symbol_table_test.rb
+++ b/test/unit/symbol_table_test.rb
@@ -13,4 +13,10 @@ class SymbolTableTest < Minitest::Test
     symbol_table.define("foo", "int", :STATIC)
     assert_equal("int", symbol_table.type_of("foo"))
   end
+
+  def test_index_of_returns_index
+    symbol_table = SymbolTable.new
+    symbol_table.define("foo", "int", :STATIC)
+    assert_equal(0, symbol_table.index_of("foo"))
+  end
 end

--- a/test/unit/symbol_table_test.rb
+++ b/test/unit/symbol_table_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+require "symbol_table"
+
+class SymbolTableTest < Minitest::Test
+  def test_define_adds_new_identifier_to_symbol_table
+    symbol_table = SymbolTable.new
+    symbol_table.define("foo", "int", :STATIC)
+    assert_equal(:STATIC, symbol_table.kind_of("foo"))
+  end
+end

--- a/test/unit/symbol_table_test.rb
+++ b/test/unit/symbol_table_test.rb
@@ -7,4 +7,10 @@ class SymbolTableTest < Minitest::Test
     symbol_table.define("foo", "int", :STATIC)
     assert_equal(:STATIC, symbol_table.kind_of("foo"))
   end
+
+  def test_type_of_returns_the_type_of_identifier
+    symbol_table = SymbolTable.new
+    symbol_table.define("foo", "int", :STATIC)
+    assert_equal("int", symbol_table.type_of("foo"))
+  end
 end

--- a/test/unit/symbol_table_test.rb
+++ b/test/unit/symbol_table_test.rb
@@ -8,6 +8,11 @@ class SymbolTableTest < Minitest::Test
     assert_equal(:STATIC, symbol_table.kind_of("foo"))
   end
 
+  def test_kind_of_returns_none_if_no_kind_given
+    symbol_table = SymbolTable.new
+    assert_equal(:NONE, symbol_table.kind_of("foo"))
+  end
+
   def test_type_of_returns_the_type_of_identifier
     symbol_table = SymbolTable.new
     symbol_table.define("foo", "int", :STATIC)
@@ -60,7 +65,7 @@ class SymbolTableTest < Minitest::Test
     assert_equal(2, symbol_table.var_count(:STATIC))
 
     symbol_table.start_subroutine
-    
+
     assert_equal(0, symbol_table.var_count(:ARG))
     assert_equal(2, symbol_table.var_count(:STATIC))
   end

--- a/test/unit/symbol_table_test.rb
+++ b/test/unit/symbol_table_test.rb
@@ -26,4 +26,14 @@ class SymbolTableTest < Minitest::Test
     symbol_table.define("bar", "boolean", :STATIC)
     assert_equal(2, symbol_table.var_count(:STATIC))
   end
+
+  def test_var_count_returns_number_of_different_kinds_of_identifier
+    symbol_table = SymbolTable.new
+    symbol_table.define("foo", "int", :STATIC)
+    symbol_table.define("bar", "boolean", :FIELD)
+    symbol_table.define("baz", "char", :STATIC)
+
+    assert_equal(2, symbol_table.var_count(:STATIC))
+    assert_equal(1, symbol_table.var_count(:FIELD))
+  end
 end

--- a/test/unit/symbol_table_test.rb
+++ b/test/unit/symbol_table_test.rb
@@ -19,4 +19,11 @@ class SymbolTableTest < Minitest::Test
     symbol_table.define("foo", "int", :STATIC)
     assert_equal(0, symbol_table.index_of("foo"))
   end
+
+  def test_var_count_returns_number_of_same_kind_of_identifier
+    symbol_table = SymbolTable.new
+    symbol_table.define("foo", "int", :STATIC)
+    symbol_table.define("bar", "boolean", :STATIC)
+    assert_equal(2, symbol_table.var_count(:STATIC))
+  end
 end

--- a/test/unit/symbol_table_test.rb
+++ b/test/unit/symbol_table_test.rb
@@ -14,10 +14,22 @@ class SymbolTableTest < Minitest::Test
     assert_equal("int", symbol_table.type_of("foo"))
   end
 
-  def test_index_of_returns_index
+  def test_index_of_one_returns_index
     symbol_table = SymbolTable.new
     symbol_table.define("foo", "int", :STATIC)
     assert_equal(0, symbol_table.index_of("foo"))
+  end
+
+  def test_index_of_returns_index_with_various_identifiers
+    symbol_table = SymbolTable.new
+    symbol_table.define("foo", "int", :STATIC)
+    symbol_table.define("bar", "boolean", :FIELD)
+    symbol_table.define("baz", "char", :STATIC)
+    symbol_table.define("too", "boolean", :FIELD)
+    symbol_table.define("tar", "int", :STATIC)
+
+    assert_equal(1, symbol_table.index_of("too"))
+    assert_equal(2, symbol_table.index_of("tar"))
   end
 
   def test_var_count_returns_number_of_same_kind_of_identifier


### PR DESCRIPTION
Add a new class SymbolTable which will assist the final compiler in keeping track of identifiers found in the program. There are kinds of identifiers can be categorized as class scope and subroutine scope. Identifiers on the class scope are `STATIC` and `FIELD` while `ARG` and `VAR` are on the subroutine scope. 