### PR TITLE
Update `Gemfile.lock`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,4 +13,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-  2.2.22
+   2.3.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Our lockfile’s a bit stale for macOS Monterey and Ruby 3.1. These commits bring it up to date.