### PR TITLE
Rename unused local variables in `CompilationEngine`

### DIFF
--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -62,7 +62,7 @@ class CompilationEngine
   def compile_subroutine
     @symbol_table.start_subroutine
 
-    kind = @tokenizer.key_word
+    _kind = @tokenizer.key_word
     output_token # constructor / function / method
 
     @subroutine_type = type = @tokenizer.key_word
@@ -250,7 +250,7 @@ class CompilationEngine
       output_token # )
 
     else
-      name = @tokenizer.identifier
+      _name = @tokenizer.identifier
       output_token # int / str / keyword / identifier / start of a subroutine call
 
       if symbol_token?("[")


### PR DESCRIPTION
By default, `Rake::TestTask` will run the tests with the [warning flag set](https://github.com/ruby/rake/blob/v13.0.6/lib/rake/testtask.rb#L52-L55), which makes Ruby emit a warning about any unused local variables.

In `CompilationEngine` we’re not currently making use of a couple of values from the tokenizer because we’ve not yet implemented all of the code generation, so at the moment they’re being assigned to unused local variables and therefore generating warnings:

```
lib/compilation_engine.rb:65: warning: assigned but unused variable - kind
lib/compilation_engine.rb:253: warning: assigned but unused variable - name
```

By temporarily renaming these variables to begin with an underscore, we can show Ruby that we’re intentionally leaving the value unused (i.e. the name is just documentation), which silences the warning. We can rename them back to remove the underscore once we’re ready to use them.