### PR TITLE
Create a AST for expressions 

### DIFF
--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -292,9 +292,7 @@ class CompilationEngine
     end
 
     @vm_writer.write_function("#{@class_name}.#{@subroutine_name}", @symbol_table.var_count(:VAR))
-
     compile_statements
-
     advance # }
   end
 

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -2,6 +2,7 @@ require 'cgi'
 require_relative 'jack_tokenizer'
 require_relative 'symbol_table'
 require_relative 'vm_writer'
+require_relative 'expression_parser'
 
 class CompilationEngine
   def initialize(input, output, tokenizer: JackTokenizer.new(input))
@@ -206,18 +207,26 @@ class CompilationEngine
     end
   end
 
-  OP_SYMBOLS = %w[+ - * / & | < > =]
-
   def compile_expression
-    compile_term
+    # step 1: build an AST that represents the expression
+    ast = ExpressionParser.new(@tokenizer).parse_expression
 
-    while symbol_token?(*OP_SYMBOLS)
-      operator_symbol = @tokenizer.symbol
-      output_token # op symbol
-      compile_term
-    end
+    @output.puts ast
+    # step 2: print out the VM code for that AST
+    ast.write_vm_code(@vm_writer)
 
-    write_operator(operator_symbol)
+  #   @stack = []
+  #   compile_term
+
+  #   while symbol_token?(*OP_SYMBOLS)
+  #     operator_symbol = @tokenizer.symbol
+  #     @stack << operator_symbol
+  #     output_token # op symbol
+  #     compile_term
+  #   end
+
+  #   @output.puts @ast
+  #   write_operator(operator_symbol)
   end
 
   def compile_expression_list

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -209,25 +209,8 @@ class CompilationEngine
   end
 
   def compile_expression
-    # step 1: build an AST that represents the expression
     ast = @expression_parser.parse_expression
-
-    @output.puts ast
-    # step 2: print out the VM code for that AST
     ast.write_vm_code(@vm_writer)
-
-  #   @stack = []
-  #   compile_term
-
-  #   while symbol_token?(*OP_SYMBOLS)
-  #     operator_symbol = @tokenizer.symbol
-  #     @stack << operator_symbol
-  #     output_token # op symbol
-  #     compile_term
-  #   end
-
-  #   @output.puts @ast
-  #   write_operator(operator_symbol)
   end
 
   def compile_expression_list

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -311,21 +311,9 @@ class CompilationEngine
   end
 
   def compile_subroutine_call
-    class_name = @tokenizer.identifier
-    output_token # subroutineName
-
-    if symbol_token?(".")
-      output_token # .
-      subroutine_name = @tokenizer.identifier
-      output_token # subroutineName
-    end
-
-    output_token # (
-    compile_expression_list
-    output_token # )
-    output_token # ;
-
-    @vm_writer.write_call("#{class_name}.#{subroutine_name}", @expressions_count)
+    parser = ExpressionParser.new(@tokenizer)
+    parser.parse_term.write_vm_code(@vm_writer)
+    advance # ; 
     @vm_writer.write_pop(:TEMP, 0)
   end
 

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -148,7 +148,9 @@ class CompilationEngine
   end
 
   def compile_return
-    output_token # return
+    @vm_writer.write_push(:CONST, 0)
+    @vm_writer.write_return
+    advance
 
     unless symbol_token?(";")
       compile_expression
@@ -305,20 +307,6 @@ class CompilationEngine
   end
 
   def output_token
-    case tokenizer.token_type
-    when :INT_CONST
-      @vm_writer.write_push(:CONST, tokenizer.int_val)
-    when :KEYWORD
-      token = tokenizer.key_word.downcase.to_s
-      case token
-      when "return"
-        if @subroutine_type == :VOID
-          @vm_writer.write_push(:CONST, 0)
-          @vm_writer.write_return
-        end
-      end
-    end
-
     advance
   end
 

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -17,12 +17,12 @@ class CompilationEngine
 
   def compile_class
     advance
-    output_token # class
+    advance # class
 
     @class_name = @tokenizer.identifier
-    output_token # className
+    advance # className
 
-    output_token # {
+    advance # {
 
     until symbol_token?("}")
       case @tokenizer.key_word
@@ -33,49 +33,49 @@ class CompilationEngine
       end
     end
 
-    output_token # }
+    advance # }
   end
 
   def compile_class_var_dec
     kind = @tokenizer.key_word
-    output_token # static / field
+    advance # static / field
 
     type = @tokenizer.key_word
-    output_token # type
+    advance # type
 
     name = @tokenizer.identifier
-    output_token # varName
+    advance # varName
 
     @symbol_table.define(name, type, kind)
 
     while symbol_token?(",")
-      output_token # ,
+      advance # ,
 
       name = @tokenizer.identifier
-      output_token # varName
+      advance # varName
 
       @symbol_table.define(name, type, kind)
       @output.puts("(#{@symbol_table.kind_of(name)}, defined, true, #{@symbol_table.index_of(name)})")
     end
 
-    output_token # ;
+    advance # ;
   end
 
   def compile_subroutine
     @symbol_table.start_subroutine
 
     _kind = @tokenizer.key_word
-    output_token # constructor / function / method
+    advance # constructor / function / method
 
     @subroutine_type = type = @tokenizer.key_word
-    output_token # void / type
+    advance # void / type
 
     @subroutine_name = @tokenizer.identifier
-    output_token # subroutineName
+    advance # subroutineName
 
-    output_token # (
+    advance # (
     compile_parameter_list
-    output_token # )
+    advance # )
 
     compile_subroutine_body
   end
@@ -85,21 +85,21 @@ class CompilationEngine
     unless symbol_token?(")")
       kind = :ARG
       type = @tokenizer.key_word
-      output_token # type
+      advance # type
 
       name = @tokenizer.identifier
-      output_token # varName
+      advance # varName
 
       @symbol_table.define(name, type, kind)
 
       while symbol_token?(",")
-        output_token # ,
+        advance # ,
 
         type = @tokenizer.key_word
-        output_token # type
+        advance # type
 
         name = @tokenizer.identifier
-        output_token # varName
+        advance # varName
 
         @symbol_table.define(name, type, kind)
       end
@@ -108,26 +108,26 @@ class CompilationEngine
 
   def compile_var_dec
     kind = @tokenizer.key_word
-    output_token # var
+    advance # var
 
     type = @tokenizer.key_word
-    output_token # type
+    advance # type
 
     name = @tokenizer.identifier
-    output_token # varName
+    advance # varName
 
     @symbol_table.define(name, type, kind)
 
     while symbol_token?(",")
-      output_token # ,
+      advance # ,
 
       name = @tokenizer.identifier
-      output_token # varName
+      advance # varName
 
       @symbol_table.define(name, type, kind)
     end
 
-    output_token # ;
+    advance # ;
   end
 
   def compile_statements
@@ -156,57 +156,57 @@ class CompilationEngine
       compile_expression
     end
 
-    output_token # ;
+    advance # ;
   end
 
   def compile_let
-    output_token # let
+    advance # let
 
     variable_name = @tokenizer.identifier
-    output_token # varName
+    advance # varName
 
     if symbol_token?("[")
-      output_token # [
+      advance # [
       compile_expression
-      output_token # ]
+      advance # ]
     end
 
-    output_token # =
+    advance # =
 
     compile_expression # expression
     @vm_writer.write_pop(:LOCAL, @symbol_table.index_of(variable_name))
 
-    output_token # ;
+    advance # ;
   end
 
   def compile_while
-    output_token # while
+    advance # while
 
-    output_token # (
+    advance # (
     compile_expression
-    output_token # )
+    advance # )
 
-    output_token # {
+    advance # {
     compile_statements
-    output_token # }
+    advance # }
   end
 
   def compile_if
-    output_token # if
+    advance # if
 
-    output_token # (
+    advance # (
     compile_expression
-    output_token # )
+    advance # )
 
-    output_token # {
+    advance # {
     compile_statements
-    output_token # }
+    advance # }
 
     if keyword_token?(:ELSE)
-      output_token # else
-      output_token # {
+      advance # else
+      advance # {
       compile_statements
-      output_token # }
+      advance # }
     end
   end
 
@@ -222,7 +222,7 @@ class CompilationEngine
       @expressions_count += 1
 
       while symbol_token?(",")
-        output_token # ,
+        advance # ,
         compile_expression
         @expressions_count += 1
       end
@@ -230,21 +230,21 @@ class CompilationEngine
   end
 
   def compile_do
-    output_token # do
+    advance # do
     compile_subroutine_call
   end
 
   def compile_term
     if symbol_token?("-", "~")
       unary_op = @tokenizer.symbol
-      output_token # unary op
+      advance # unary op
       compile_term
       @vm_writer.write_arithmetic(:NEG) if unary_op == "-"
 
     elsif symbol_token?("(")
-      output_token # (
+      advance # (
       compile_expression
-      output_token # )
+      advance # )
 
     else
       name = @tokenizer.identifier
@@ -253,27 +253,27 @@ class CompilationEngine
         @vm_writer.write_push(:LOCAL, @symbol_table.index_of(name))
       end
 
-      output_token # int / str / keyword / identifier / start of a subroutine call
+      advance # int / str / keyword / identifier / start of a subroutine call
 
       if symbol_token?("[")
-        output_token # [
+        advance # [
         compile_expression
-        output_token # ]
+        advance # ]
 
       elsif symbol_token?("(")
-        output_token # (
+        advance # (
         compile_expression_list
-        output_token # )
+        advance # )
 
       elsif symbol_token?(".")
-        output_token # .
+        advance # .
 
         subroutine_name = @tokenizer.identifier
-        output_token # subroutineName
+        advance # subroutineName
 
-        output_token # (
+        advance # (
         compile_expression_list
-        output_token # )
+        advance # )
 
         @vm_writer.write_call("#{name}.#{subroutine_name}", @expressions_count)
       end
@@ -283,7 +283,7 @@ class CompilationEngine
   private
 
   def compile_subroutine_body
-    output_token # {
+    advance # {
 
     while keyword_token?(:VAR)
       compile_var_dec
@@ -293,7 +293,7 @@ class CompilationEngine
 
     compile_statements
 
-    output_token # }
+    advance # }
   end
 
   def compile_subroutine_call
@@ -304,10 +304,6 @@ class CompilationEngine
 
   def advance
     @tokenizer.has_more_tokens? && @tokenizer.advance
-  end
-
-  def output_token
-    advance
   end
 
   def symbol_token?(*symbols)

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -236,52 +236,6 @@ class CompilationEngine
     @vm_writer.write_pop(:TEMP, 0)
   end
 
-  def compile_term
-    if symbol_token?("-", "~")
-      unary_op = @tokenizer.symbol
-      advance # unary op
-      compile_term
-      @vm_writer.write_arithmetic(:NEG) if unary_op == "-"
-
-    elsif symbol_token?("(")
-      advance # (
-      compile_expression
-      advance # )
-
-    else
-      name = @tokenizer.identifier
-
-      if @symbol_table.kind_of(name) == :VAR
-        @vm_writer.write_push(:LOCAL, @symbol_table.index_of(name))
-      end
-
-      advance # int / str / keyword / identifier / start of a subroutine call
-
-      if symbol_token?("[")
-        advance # [
-        compile_expression
-        advance # ]
-
-      elsif symbol_token?("(")
-        advance # (
-        compile_expression_list
-        advance # )
-
-      elsif symbol_token?(".")
-        advance # .
-
-        subroutine_name = @tokenizer.identifier
-        advance # subroutineName
-
-        advance # (
-        compile_expression_list
-        advance # )
-
-        @vm_writer.write_call("#{name}.#{subroutine_name}", @expressions_count)
-      end
-    end
-  end
-
   private
 
   def compile_subroutine_body

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -317,13 +317,4 @@ class CompilationEngine
       @tokenizer.token_type == :KEYWORD && @tokenizer.key_word == keyword
     end
   end
-
-  def write_operator(symbol)
-    case symbol
-    when "*"
-      @vm_writer.write_call("Math.multiply", 2)
-    when "+"
-      @vm_writer.write_arithmetic(:ADD)
-    end
-  end
 end

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -10,6 +10,7 @@ class CompilationEngine
     @tokenizer = tokenizer
     @symbol_table = SymbolTable.new
     @vm_writer = VMWriter.new(output)
+    @expression_parser = ExpressionParser.new(@tokenizer)
   end
 
   attr_reader :tokenizer
@@ -209,7 +210,7 @@ class CompilationEngine
 
   def compile_expression
     # step 1: build an AST that represents the expression
-    ast = ExpressionParser.new(@tokenizer).parse_expression
+    ast = @expression_parser.parse_expression
 
     @output.puts ast
     # step 2: print out the VM code for that AST
@@ -311,9 +312,8 @@ class CompilationEngine
   end
 
   def compile_subroutine_call
-    parser = ExpressionParser.new(@tokenizer)
-    parser.parse_term.write_vm_code(@vm_writer)
-    advance # ; 
+    @expression_parser.parse_term.write_vm_code(@vm_writer)
+    advance # ;
     @vm_writer.write_pop(:TEMP, 0)
   end
 

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -231,7 +231,9 @@ class CompilationEngine
 
   def compile_do
     advance # do
-    compile_subroutine_call
+    @expression_parser.parse_term.write_vm_code(@vm_writer)
+    advance # ;
+    @vm_writer.write_pop(:TEMP, 0)
   end
 
   def compile_term
@@ -294,12 +296,6 @@ class CompilationEngine
     compile_statements
 
     advance # }
-  end
-
-  def compile_subroutine_call
-    @expression_parser.parse_term.write_vm_code(@vm_writer)
-    advance # ;
-    @vm_writer.write_pop(:TEMP, 0)
   end
 
   def advance

--- a/lib/compilation_engine.rb
+++ b/lib/compilation_engine.rb
@@ -10,7 +10,7 @@ class CompilationEngine
     @tokenizer = tokenizer
     @symbol_table = SymbolTable.new
     @vm_writer = VMWriter.new(output)
-    @expression_parser = ExpressionParser.new(@tokenizer)
+    @expression_parser = ExpressionParser.new(@tokenizer, @symbol_table)
   end
 
   attr_reader :tokenizer

--- a/lib/expression_parser.rb
+++ b/lib/expression_parser.rb
@@ -127,6 +127,8 @@ class ExpressionParser
     list
   end
 
+  private
+
   def symbol_token?(*symbols)
     @tokenizer.token_type == :SYMBOL && symbols.include?(@tokenizer.symbol)
   end

--- a/lib/expression_parser.rb
+++ b/lib/expression_parser.rb
@@ -110,7 +110,7 @@ class ExpressionParser
       end
     end
 
-    return ast
+    ast
   end
 
   def parse_expression_list

--- a/lib/expression_parser.rb
+++ b/lib/expression_parser.rb
@@ -98,13 +98,12 @@ class ExpressionParser
         advance
 
         if symbol_token?(".")
-          advance
+          advance # subroutine name
           subroutine_name = @tokenizer.identifier
-          advance
-
-          advance
+          advance # (
+          advance # )
           list = parse_expression_list
-          advance
+          advance # ;
           ast = SubroutineCall.new(name, subroutine_name, list)
         end
       end

--- a/lib/expression_parser.rb
+++ b/lib/expression_parser.rb
@@ -98,12 +98,13 @@ class ExpressionParser
         advance
 
         if symbol_token?(".")
-          advance # subroutine name
+          advance
           subroutine_name = @tokenizer.identifier
-          advance # (
-          advance # )
+          advance
+
+          advance
           list = parse_expression_list
-          advance # ;
+          advance
           ast = SubroutineCall.new(name, subroutine_name, list)
         end
       end

--- a/lib/expression_parser.rb
+++ b/lib/expression_parser.rb
@@ -6,6 +6,8 @@ ArithmeticOp = Struct.new(:operator, :left, :right) do
     case operator
     when "+"
       vm_writer.write_arithmetic(:ADD)
+    when "*"
+      vm_writer.write_call("Math.multiply", 2)
     end
   end
 end

--- a/lib/expression_parser.rb
+++ b/lib/expression_parser.rb
@@ -1,0 +1,46 @@
+ArithmeticOp = Struct.new(:operator, :left, :right) do
+  def write_vm_code(vm_writer)
+    left.write_vm_code(vm_writer)
+    right.write_vm_code(vm_writer)
+
+    case operator
+    when "+"
+      vm_writer.write_arithmetic(:ADD)
+    end
+  end
+end
+
+Number = Struct.new(:value) do
+  def write_vm_code(vm_writer)
+    vm_writer.write_push(:CONST, value)
+  end
+end
+
+UnaryOp = Struct.new(:operator, :operand)
+
+OP_SYMBOLS = %w[+ - * / & | < > =]
+
+class ExpressionParser
+  def initialize(tokenizer)
+    @tokenizer = tokenizer
+  end
+
+  def parse_expression
+    left = parse_term
+
+    if @tokenizer.token_type == :SYMBOL && OP_SYMBOLS.include?(@tokenizer.symbol)
+      operator = @tokenizer.symbol
+      @tokenizer.advance
+      right = parse_expression
+      ArithmeticOp.new(operator, left, right)
+    else
+      left
+    end
+  end
+
+  def parse_term
+    ast = Number.new(@tokenizer.int_val)
+    @tokenizer.advance
+    ast
+  end
+end

--- a/lib/expression_parser.rb
+++ b/lib/expression_parser.rb
@@ -38,11 +38,12 @@ class ExpressionParser
   def parse_expression
     left = parse_term
 
-    if @tokenizer.token_type == :SYMBOL && OP_SYMBOLS.include?(@tokenizer.symbol)
+    if symbol_token?(*OP_SYMBOLS)
       operator = @tokenizer.symbol
       @tokenizer.advance
       right = parse_expression
       ArithmeticOp.new(operator, left, right)
+
     else
       left
     end
@@ -55,12 +56,24 @@ class ExpressionParser
       @tokenizer.advance
 
     when :SYMBOL
-      operator = @tokenizer.symbol
-      @tokenizer.advance
-      operand = parse_expression
-      ast = UnaryOp.new(operator, operand)
+      symbol = @tokenizer.symbol
+
+      if symbol_token?("-", "~")
+        @tokenizer.advance
+        operand = parse_expression
+        ast = UnaryOp.new(symbol, operand)
+
+      elsif symbol_token?("(")
+        @tokenizer.advance
+        ast = parse_expression
+        @tokenizer.advance
+      end
     end
 
     ast
+  end
+
+  def symbol_token?(*symbols)
+    @tokenizer.token_type == :SYMBOL && symbols.include?(@tokenizer.symbol)
   end
 end

--- a/lib/expression_parser.rb
+++ b/lib/expression_parser.rb
@@ -40,7 +40,7 @@ class ExpressionParser
 
     if symbol_token?(*OP_SYMBOLS)
       operator = @tokenizer.symbol
-      @tokenizer.advance
+      advance
       right = parse_expression
       ArithmeticOp.new(operator, left, right)
 
@@ -53,20 +53,20 @@ class ExpressionParser
     case @tokenizer.token_type
     when :INT_CONST
       ast = Number.new(@tokenizer.int_val)
-      @tokenizer.advance
+      advance
 
     when :SYMBOL
       symbol = @tokenizer.symbol
 
       if symbol_token?("-", "~")
-        @tokenizer.advance
+        advance
         operand = parse_expression
         ast = UnaryOp.new(symbol, operand)
 
       elsif symbol_token?("(")
-        @tokenizer.advance
+        advance
         ast = parse_expression
-        @tokenizer.advance
+        advance
       end
     end
 
@@ -75,5 +75,9 @@ class ExpressionParser
 
   def symbol_token?(*symbols)
     @tokenizer.token_type == :SYMBOL && symbols.include?(@tokenizer.symbol)
+  end
+
+  def advance
+    @tokenizer.has_more_tokens? && @tokenizer.advance
   end
 end


### PR DESCRIPTION
# Changes

* New AST for expressions! In order to evaluate expressions properly, we need ASTs
* Create new class `ExpressionParser` and AST structs 
* Port current functionality to use the `ExpressionParser`
* Some clean up and dead code removal 