### PR TITLE
Use `ruby` platform in lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,9 +5,7 @@ GEM
     rake (13.0.4)
 
 PLATFORMS
-  x86_64-darwin-20
-  x86_64-darwin-21
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   minitest


### PR DESCRIPTION
A month ago I added `x86_64-darwin-21` in #18 and now I need to add `arm64-darwin-21` because I’ve moved to an M1 Mac. Let’s just switch to `ruby` and be done with this madness.